### PR TITLE
geom_alt props

### DIFF
--- a/data/421/176/099/421176099.geojson
+++ b/data/421/176/099/421176099.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"CU",
     "wof:created":1459009095,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c004218c26455de557800ac21988fb91",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":421176099,
-    "wof:lastmodified":1563321524,
+    "wof:lastmodified":1582379478,
     "wof:name":"G\u00fcines",
     "wof:parent_id":1091904955,
     "wof:placetype":"locality",

--- a/data/421/186/583/421186583.geojson
+++ b/data/421/186/583/421186583.geojson
@@ -461,6 +461,9 @@
     ],
     "wof:country":"CU",
     "wof:created":1459009485,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf1ca4ad5c4714b88decd1c49366a4bd",
     "wof:hierarchy":[
         {
@@ -472,7 +475,7 @@
         }
     ],
     "wof:id":421186583,
-    "wof:lastmodified":1564328109,
+    "wof:lastmodified":1582379477,
     "wof:name":"Havana",
     "wof:parent_id":85670445,
     "wof:placetype":"locality",

--- a/data/421/190/349/421190349.geojson
+++ b/data/421/190/349/421190349.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"CU",
     "wof:created":1459009655,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"47d0297930aaee451df8010d7b362e33",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421190349,
-    "wof:lastmodified":1561766481,
+    "wof:lastmodified":1582379478,
     "wof:name":"San Luis",
     "wof:parent_id":1360667253,
     "wof:placetype":"locality",

--- a/data/856/326/75/85632675.geojson
+++ b/data/856/326/75/85632675.geojson
@@ -936,6 +936,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl:centroid":"mapshaper",
@@ -991,6 +992,11 @@
     },
     "wof:country":"CU",
     "wof:country_alpha3":"CUB",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"417fb94c933f635fde8e0badf7f84f0c",
     "wof:hierarchy":[
         {
@@ -1005,7 +1011,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670838,
+    "wof:lastmodified":1582379459,
     "wof:name":"Cuba",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/326/75/85632675.geojson
+++ b/data/856/326/75/85632675.geojson
@@ -936,7 +936,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl:centroid":"mapshaper",
@@ -1011,7 +1010,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1582379459,
+    "wof:lastmodified":1583259959,
     "wof:name":"Cuba",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/704/03/85670403.geojson
+++ b/data/856/704/03/85670403.geojson
@@ -317,6 +317,9 @@
         "wk:page":"Cienfuegos Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2adb42caf32fde40d185193e079c3cf9",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670835,
+    "wof:lastmodified":1582379456,
     "wof:name":"Cienfuegos",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/05/85670405.geojson
+++ b/data/856/704/05/85670405.geojson
@@ -300,6 +300,9 @@
         "wd:id":"Q12588"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ba979cff090434ea41ac829bb5aad0f0",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670836,
+    "wof:lastmodified":1582379456,
     "wof:name":"Isla de la Juventud",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/09/85670409.geojson
+++ b/data/856/704/09/85670409.geojson
@@ -330,6 +330,9 @@
         "wk:page":"Pinar del R\u00edo Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd4df99d0b4340c5d240dfb64dfd29ed",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670836,
+    "wof:lastmodified":1582379456,
     "wof:name":"Pinar Del Rio",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/13/85670413.geojson
+++ b/data/856/704/13/85670413.geojson
@@ -322,6 +322,9 @@
         "wk:page":"Sancti Sp\u00edritus Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"985871f23d26167be8670707d392955b",
     "wof:hierarchy":[
         {
@@ -337,7 +340,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670838,
+    "wof:lastmodified":1582379458,
     "wof:name":"Sancti Spiritus",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/19/85670419.geojson
+++ b/data/856/704/19/85670419.geojson
@@ -313,6 +313,9 @@
         "wk:page":"Ciego de \u00c1vila Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc4a170bf41534536a4e66b163b8d26e",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670836,
+    "wof:lastmodified":1582379456,
     "wof:name":"Ciego de \u00c1vila",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/23/85670423.geojson
+++ b/data/856/704/23/85670423.geojson
@@ -326,6 +326,9 @@
         "wk:page":"Camag\u00fcey Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"615cc4701b89de97d87b8ddbd0652f40",
     "wof:hierarchy":[
         {
@@ -341,7 +344,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670837,
+    "wof:lastmodified":1582379458,
     "wof:name":"Camag\u00fcey",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/25/85670425.geojson
+++ b/data/856/704/25/85670425.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Guant\u00e1namo Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0b73bd7d21f2d32d99c66551d47010ff",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670838,
+    "wof:lastmodified":1582379458,
     "wof:name":"Guantanamo",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/31/85670431.geojson
+++ b/data/856/704/31/85670431.geojson
@@ -326,6 +326,9 @@
         "wk:page":"Granma Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"31f0df09129c61a0db6f56d545c64389",
     "wof:hierarchy":[
         {
@@ -341,7 +344,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670836,
+    "wof:lastmodified":1582379457,
     "wof:name":"Granma",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/35/85670435.geojson
+++ b/data/856/704/35/85670435.geojson
@@ -333,6 +333,9 @@
         "wk:page":"Holgu\u00edn Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5db6a85b6cde37894efb5690de5efabb",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670836,
+    "wof:lastmodified":1582379456,
     "wof:name":"Holguin",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/39/85670439.geojson
+++ b/data/856/704/39/85670439.geojson
@@ -320,6 +320,9 @@
         "wk:page":"Las Tunas Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9868c6380a8e3a2b2e1cc160368223b4",
     "wof:hierarchy":[
         {
@@ -335,7 +338,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670837,
+    "wof:lastmodified":1582379457,
     "wof:name":"Las Tunas",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/41/85670441.geojson
+++ b/data/856/704/41/85670441.geojson
@@ -313,6 +313,9 @@
         "wk:page":"Santiago de Cuba Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ffea9481e69685b5e060d71bd858184f",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670837,
+    "wof:lastmodified":1582379457,
     "wof:name":"Santiago de Cuba",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/45/85670445.geojson
+++ b/data/856/704/45/85670445.geojson
@@ -234,6 +234,9 @@
         421186583
     ],
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf1ca4ad5c4714b88decd1c49366a4bd",
     "wof:hierarchy":[
         {
@@ -249,7 +252,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670836,
+    "wof:lastmodified":1582379456,
     "wof:name":"Ciudad De La Habana",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/49/85670449.geojson
+++ b/data/856/704/49/85670449.geojson
@@ -236,6 +236,9 @@
         "wd:id":"Q115006"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1badd9023b155b46efde6710acd1c5d0",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670837,
+    "wof:lastmodified":1582379458,
     "wof:name":"Artemisa",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/55/85670455.geojson
+++ b/data/856/704/55/85670455.geojson
@@ -329,6 +329,9 @@
         "wk:page":"Matanzas Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f15fa8a52aa8c8d8c68684d7c9af929b",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670837,
+    "wof:lastmodified":1582379457,
     "wof:name":"Matanzas",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/57/85670457.geojson
+++ b/data/856/704/57/85670457.geojson
@@ -305,6 +305,9 @@
         "wk:page":"Villa Clara Province"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a80db67b15285ba25e669218b1521716",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670835,
+    "wof:lastmodified":1582379455,
     "wof:name":"Villa Clara",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/61/85670461.geojson
+++ b/data/856/704/61/85670461.geojson
@@ -123,6 +123,9 @@
         "wd:id":"Q1914389"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"acb30ccd4998a865c5b5e70787c51918",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1565670835,
+    "wof:lastmodified":1582379455,
     "wof:name":"Mayabeque",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/857/935/33/85793533.geojson
+++ b/data/857/935/33/85793533.geojson
@@ -73,6 +73,9 @@
         "qs:id":1082590
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66415f6f03c9334aee7241de88b200a8",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379264,
+    "wof:lastmodified":1582379454,
     "wof:name":"Aldecoa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/39/85793539.geojson
+++ b/data/857/935/39/85793539.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":423358
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5bb503ba2b95d9009f1fc902fc13f063",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379264,
+    "wof:lastmodified":1582379454,
     "wof:name":"Alturas de Miramar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/43/85793543.geojson
+++ b/data/857/935/43/85793543.geojson
@@ -81,6 +81,9 @@
         "qs:id":228194
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"668d7e829fd143c80e009a7f48ad12fe",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379264,
+    "wof:lastmodified":1582379454,
     "wof:name":"Bel\u00e9n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/69/85793569.geojson
+++ b/data/857/935/69/85793569.geojson
@@ -143,6 +143,9 @@
         "qs:id":1165054
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d378ab7fe55d8cfbcd2204a4cf6b6c08",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1564326352,
+    "wof:lastmodified":1582379454,
     "wof:name":"Belvedere",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/73/85793573.geojson
+++ b/data/857/935/73/85793573.geojson
@@ -140,6 +140,9 @@
         "wk:page":"Centro Habana"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ba3a8e72ca2a5e9832174112a3bdddd",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1563319838,
+    "wof:lastmodified":1582379454,
     "wof:name":"Centro Habana",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/75/85793575.geojson
+++ b/data/857/935/75/85793575.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Cerro, Havana"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3978b46a369edce20d638d018767b713",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1563319839,
+    "wof:lastmodified":1582379454,
     "wof:name":"Cerro",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/79/85793579.geojson
+++ b/data/857/935/79/85793579.geojson
@@ -66,10 +66,10 @@
     ],
     "src:lbl:centroid":"yerbashapes",
     "wof:belongsto":[
+        85670445,
         102191575,
         85632675,
-        1091907083,
-        85670445
+        1091907083
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,6 +78,9 @@
         "qs:id":211058
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee405aada5c2601b1d0d08de988f77b1",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1531861388,
+    "wof:lastmodified":1582379454,
     "wof:name":"Cubanac\u00e1n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/83/85793583.geojson
+++ b/data/857/935/83/85793583.geojson
@@ -129,6 +129,9 @@
         "qs_pg:id":889974
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ffe802a3930815f10141d7d371274c87",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379265,
+    "wof:lastmodified":1582379454,
     "wof:name":"Distrito Jos\u00e9 Mart\u00ed",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/85/85793585.geojson
+++ b/data/857/935/85/85793585.geojson
@@ -118,6 +118,9 @@
         "wd:id":"Q2595454"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c7e2d752ed100795479c39c2fa685215",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1563319840,
+    "wof:lastmodified":1582379454,
     "wof:name":"Antonio Guiteras",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/91/85793591.geojson
+++ b/data/857/935/91/85793591.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Habana del Este"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4385fa6b14e2359421d435e94f062a27",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1563319839,
+    "wof:lastmodified":1582379454,
     "wof:name":"Habana del Este",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/95/85793595.geojson
+++ b/data/857/935/95/85793595.geojson
@@ -87,16 +87,19 @@
     ],
     "src:lbl:centroid":"yerbashapes",
     "wof:belongsto":[
+        85670445,
         102191575,
         85632675,
-        1091904421,
-        85670445
+        1091904421
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":63124
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c5a09b4b66bd6a323cf29f97e66bfd8",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1531861391,
+    "wof:lastmodified":1582379454,
     "wof:name":"Jes\u00fas del Monte",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/99/85793599.geojson
+++ b/data/857/935/99/85793599.geojson
@@ -162,6 +162,9 @@
         "gp:id":63520
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29f119c019d4dce495cb3e96dbf4e202",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1564326352,
+    "wof:lastmodified":1582379454,
     "wof:name":"La Ceiba",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/03/85793603.geojson
+++ b/data/857/936/03/85793603.geojson
@@ -176,6 +176,9 @@
         "wk:page":"Old Havana"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ad4c8850d46117d985428301e6cbd664",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1563319833,
+    "wof:lastmodified":1582379452,
     "wof:name":"La Habana Vieja",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/05/85793605.geojson
+++ b/data/857/936/05/85793605.geojson
@@ -107,6 +107,10 @@
         "wk:page":"Playa, Havana"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0109b41bdd0be76ca7e9ddd271eeb98d",
     "wof:hierarchy":[
         {
@@ -121,7 +125,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1563319833,
+    "wof:lastmodified":1582379454,
     "wof:name":"La Playa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/11/85793611.geojson
+++ b/data/857/936/11/85793611.geojson
@@ -104,6 +104,9 @@
         "qs_pg:id":887547
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e29401863949a3a24dec12bebf306979",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1564326347,
+    "wof:lastmodified":1582379454,
     "wof:name":"La Reforma",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/15/85793615.geojson
+++ b/data/857/936/15/85793615.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":982546
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66fd883f54a46bbb243ec25ef94e816c",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379264,
+    "wof:lastmodified":1582379454,
     "wof:name":"La Risue\u00f1a",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/19/85793619.geojson
+++ b/data/857/936/19/85793619.geojson
@@ -73,6 +73,9 @@
         "qs:id":1340775
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"691400865c8058f7883ee31501158d01",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379264,
+    "wof:lastmodified":1582379454,
     "wof:name":"La Sierra",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/23/85793623.geojson
+++ b/data/857/936/23/85793623.geojson
@@ -73,10 +73,10 @@
     "src:lbl:centroid":"yerbashapes",
     "wd:wordcount":169,
     "wof:belongsto":[
+        85670445,
         102191575,
         85632675,
-        1091904421,
-        85670445
+        1091904421
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -84,6 +84,9 @@
         "qs:id":1043422
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"06ba88bf6f785f2f4d28c399079ae8ec",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1531861396,
+    "wof:lastmodified":1582379454,
     "wof:name":"La V\u00edbora",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/29/85793629.geojson
+++ b/data/857/936/29/85793629.geojson
@@ -79,6 +79,9 @@
         "wk:page":"Miramar, Havana"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"27209a08be7c79a338f0f99529382a21",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379265,
+    "wof:lastmodified":1582379454,
     "wof:name":"Miramar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/33/85793633.geojson
+++ b/data/857/936/33/85793633.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":240930
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b0dd8bb3e65cb7df370a634f7b83b26",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379265,
+    "wof:lastmodified":1582379454,
     "wof:name":"Nuevo Santiago",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/37/85793637.geojson
+++ b/data/857/936/37/85793637.geojson
@@ -77,6 +77,9 @@
         "qs:id":1340779
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e8216d817aa2bfeb8fa3d2c13a6092f",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379264,
+    "wof:lastmodified":1582379454,
     "wof:name":"Quintero",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/41/85793641.geojson
+++ b/data/857/936/41/85793641.geojson
@@ -142,6 +142,9 @@
         "wd:id":"Q2066278"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7766899b985848e30926d5d32e6eea5",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1563319837,
+    "wof:lastmodified":1582379454,
     "wof:name":"Regla",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/47/85793647.geojson
+++ b/data/857/936/47/85793647.geojson
@@ -72,6 +72,9 @@
         "qs:id":211059
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"485d068285716111164d7c2864539292",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379265,
+    "wof:lastmodified":1582379454,
     "wof:name":"Reparto Altamira",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/51/85793651.geojson
+++ b/data/857/936/51/85793651.geojson
@@ -58,10 +58,10 @@
     ],
     "src:lbl:centroid":"yerbashapes",
     "wof:belongsto":[
+        85670441,
         102191575,
         85632675,
-        1091908137,
-        85670441
+        1091908137
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -70,6 +70,9 @@
         "qs:id":982556
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a17e1e5a6c928e7ff34c66ee98dc215",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1531861400,
+    "wof:lastmodified":1582379453,
     "wof:name":"Reparto Belmare",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/53/85793653.geojson
+++ b/data/857/936/53/85793653.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":892009
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62cbf759f250921cf4ab71fc77434436",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379265,
+    "wof:lastmodified":1582379454,
     "wof:name":"Reparto Desi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/57/85793657.geojson
+++ b/data/857/936/57/85793657.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":898502
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d3ed5ec7d4b9ba28a1eaf736e062d2ef",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379264,
+    "wof:lastmodified":1582379452,
     "wof:name":"Reparto Fomento",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/67/85793667.geojson
+++ b/data/857/936/67/85793667.geojson
@@ -72,6 +72,9 @@
         "qs:id":898504
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53a655c0bd6713554eb910992ef25291",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379265,
+    "wof:lastmodified":1582379453,
     "wof:name":"Reparto Veguita de Galo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/71/85793671.geojson
+++ b/data/857/936/71/85793671.geojson
@@ -61,10 +61,10 @@
     ],
     "src:lbl:centroid":"yerbashapes",
     "wof:belongsto":[
+        85670441,
         102191575,
         85632675,
-        1091908137,
-        85670441
+        1091908137
     ],
     "wof:breaches":[
         85793653
@@ -76,6 +76,10 @@
         "qs_pg:id":211060
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e85e8ac328fad26533ae7299432b89b9",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1531861403,
+    "wof:lastmodified":1582379454,
     "wof:name":"Reparto Vista Alegre",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/75/85793675.geojson
+++ b/data/857/936/75/85793675.geojson
@@ -573,6 +573,9 @@
         "qs_pg:id":898505
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3c13becd99b93129bb37c7b6e7888d5",
     "wof:hierarchy":[
         {
@@ -588,7 +591,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1564326350,
+    "wof:lastmodified":1582379454,
     "wof:name":"San Francisco",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/81/85793681.geojson
+++ b/data/857/936/81/85793681.geojson
@@ -150,6 +150,9 @@
         "qs_pg:id":295654
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7476919d6038304cebcd8ae2b6e34b4",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1564326350,
+    "wof:lastmodified":1582379454,
     "wof:name":"Santa Catalina",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/85/85793685.geojson
+++ b/data/857/936/85/85793685.geojson
@@ -77,6 +77,9 @@
         "qs:id":908654
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41b1f36077cbaafc1e67530ddf5be0da",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379265,
+    "wof:lastmodified":1582379454,
     "wof:name":"Santos Su\u00e1rez",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/89/85793689.geojson
+++ b/data/857/936/89/85793689.geojson
@@ -112,6 +112,9 @@
         "qs_pg:id":240477
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a59af840a1a57ab3c3c1ad5a1d03463a",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1564326347,
+    "wof:lastmodified":1582379454,
     "wof:name":"Siboney",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/91/85793691.geojson
+++ b/data/857/936/91/85793691.geojson
@@ -290,6 +290,9 @@
         "qs:id":238563
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b91863267310039045328338a3e14f94",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379265,
+    "wof:lastmodified":1582379454,
     "wof:name":"Tamarindo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/936/95/85793695.geojson
+++ b/data/857/936/95/85793695.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Vedado"
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3479571b434aa29e0a1e3929d06d430c",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1561766441,
+    "wof:lastmodified":1582379451,
     "wof:name":"Vedado",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/654/53/85865453.geojson
+++ b/data/858/654/53/85865453.geojson
@@ -59,10 +59,10 @@
     ],
     "src:lbl:centroid":"yerbashapes",
     "wof:belongsto":[
+        85670445,
         102191575,
         85632675,
-        1091907083,
-        85670445
+        1091907083
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -70,6 +70,9 @@
         "qs:id":367834
     },
     "wof:country":"CU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fc3e4e13ab26107215118e3b13e75165",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1531871115,
+    "wof:lastmodified":1582379463,
     "wof:name":"Monte Barreto",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/430/271/890430271.geojson
+++ b/data/890/430/271/890430271.geojson
@@ -305,6 +305,9 @@
     },
     "wof:country":"CU",
     "wof:created":1469051846,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e960a5404c7e3dda58e9057aabf7549b",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
         }
     ],
     "wof:id":890430271,
-    "wof:lastmodified":1563321532,
+    "wof:lastmodified":1582379478,
     "wof:name":"Bayamo",
     "wof:parent_id":1091903105,
     "wof:placetype":"locality",

--- a/data/890/440/189/890440189.geojson
+++ b/data/890/440/189/890440189.geojson
@@ -201,6 +201,9 @@
     },
     "wof:country":"CU",
     "wof:created":1469052266,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b586acdfae4c6bc4427aa5d76ed00d2c",
     "wof:hierarchy":[
         {
@@ -212,7 +215,7 @@
         }
     ],
     "wof:id":890440189,
-    "wof:lastmodified":1563321529,
+    "wof:lastmodified":1582379478,
     "wof:name":"Banes",
     "wof:parent_id":1091902915,
     "wof:placetype":"locality",

--- a/data/890/442/079/890442079.geojson
+++ b/data/890/442/079/890442079.geojson
@@ -324,6 +324,9 @@
     },
     "wof:country":"CU",
     "wof:created":1469052349,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2a18bc3246f687be4ec906d854d1cb94",
     "wof:hierarchy":[
         {
@@ -335,7 +338,7 @@
         }
     ],
     "wof:id":890442079,
-    "wof:lastmodified":1563321546,
+    "wof:lastmodified":1582379478,
     "wof:name":"Pinar del R\u00edo",
     "wof:parent_id":1091907007,
     "wof:placetype":"locality",

--- a/data/890/442/087/890442087.geojson
+++ b/data/890/442/087/890442087.geojson
@@ -271,6 +271,9 @@
     },
     "wof:country":"CU",
     "wof:created":1469052349,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"95aa28e9781b48a63cb7ab1516f946e6",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         }
     ],
     "wof:id":890442087,
-    "wof:lastmodified":1563321550,
+    "wof:lastmodified":1582379479,
     "wof:name":"Nueva Gerona",
     "wof:parent_id":1091906563,
     "wof:placetype":"locality",

--- a/data/890/442/089/890442089.geojson
+++ b/data/890/442/089/890442089.geojson
@@ -255,6 +255,9 @@
     },
     "wof:country":"CU",
     "wof:created":1469052349,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c3d3462554ccf452b5e9b08364882cc3",
     "wof:hierarchy":[
         {
@@ -266,7 +269,7 @@
         }
     ],
     "wof:id":890442089,
-    "wof:lastmodified":1561766484,
+    "wof:lastmodified":1582379479,
     "wof:name":"Mor\u00f3n",
     "wof:parent_id":1091906525,
     "wof:placetype":"locality",

--- a/data/890/442/091/890442091.geojson
+++ b/data/890/442/091/890442091.geojson
@@ -329,6 +329,9 @@
     },
     "wof:country":"CU",
     "wof:created":1469052349,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5a889472d19e5381f5998675c8e5ac8e",
     "wof:hierarchy":[
         {
@@ -340,7 +343,7 @@
         }
     ],
     "wof:id":890442091,
-    "wof:lastmodified":1563321549,
+    "wof:lastmodified":1582379478,
     "wof:name":"Matanzas",
     "wof:parent_id":1091906273,
     "wof:placetype":"locality",

--- a/data/890/442/095/890442095.geojson
+++ b/data/890/442/095/890442095.geojson
@@ -209,6 +209,9 @@
     },
     "wof:country":"CU",
     "wof:created":1469052350,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e945433cb0372a1e5f40fbddc0309c98",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":890442095,
-    "wof:lastmodified":1563321550,
+    "wof:lastmodified":1582379479,
     "wof:name":"Caibari\u00e9n",
     "wof:parent_id":1091903367,
     "wof:placetype":"locality",

--- a/data/890/444/797/890444797.geojson
+++ b/data/890/444/797/890444797.geojson
@@ -308,6 +308,9 @@
     },
     "wof:country":"CU",
     "wof:created":1469052482,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1ca28ef199ad589a433c191b416f2bac",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
         }
     ],
     "wof:id":890444797,
-    "wof:lastmodified":1563321534,
+    "wof:lastmodified":1582379478,
     "wof:name":"Las Tunas",
     "wof:parent_id":1091905619,
     "wof:placetype":"locality",

--- a/data/890/445/471/890445471.geojson
+++ b/data/890/445/471/890445471.geojson
@@ -62,6 +62,9 @@
     },
     "wof:country":"CU",
     "wof:created":1469052511,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b49233cd9e51b6591e083b2fba7f7d4c",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":890445471,
-    "wof:lastmodified":1555047431,
+    "wof:lastmodified":1582379479,
     "wof:name":"Melena Del Sur",
     "wof:parent_id":85670461,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.