### PR TITLE
cu concordances, placetype local, and more

### DIFF
--- a/data/109/190/255/5/1091902555.geojson
+++ b/data/109/190/255/5/1091902555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049848,
-    "geom:area_square_m":570680898.576353,
+    "geom:area_square_m":570680691.709444,
     "geom:bbox":"-80.830264,22.046509,-80.488845,22.365384",
     "geom:latitude":22.202634,
     "geom:longitude":-80.653851,
@@ -120,9 +120,10 @@
         "hasc:id":"CU.CF.AB",
         "wd:id":"Q331384"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892243,
-    "wof:geomhash":"bb3f425194459c6e081c56596bef442a",
+    "wof:geomhash":"09528d87aa445c4f4c06f2821c6f23cf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1091902555,
-    "wof:lastmodified":1690868521,
+    "wof:lastmodified":1695886594,
     "wof:name":"Abreus",
     "wof:parent_id":85670403,
     "wof:placetype":"county",

--- a/data/109/190/260/3/1091902603.geojson
+++ b/data/109/190/260/3/1091902603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058606,
-    "geom:area_square_m":670216453.429204,
+    "geom:area_square_m":670216453.429322,
     "geom:bbox":"-80.9311828153,22.1600243467,-80.6284340974,22.4742946811",
     "geom:latitude":22.353618,
     "geom:longitude":-80.793769,
@@ -103,9 +103,10 @@
         "hasc:id":"CU.CF.AP",
         "wd:id":"Q2245953"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892245,
-    "wof:geomhash":"c01ee2ed3e0207a321787235da91b208",
+    "wof:geomhash":"29cc1994c2e51f535fd869350b721259",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091902603,
-    "wof:lastmodified":1561766474,
+    "wof:lastmodified":1695887185,
     "wof:name":"Aguada De Pasajeros",
     "wof:parent_id":85670403,
     "wof:placetype":"county",

--- a/data/109/190/264/1/1091902641.geojson
+++ b/data/109/190/264/1/1091902641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016859,
-    "geom:area_square_m":192228896.005885,
+    "geom:area_square_m":192228782.840158,
     "geom:bbox":"-82.677544,22.680361,-82.533296,22.855121",
     "geom:latitude":22.762382,
     "geom:longitude":-82.606627,
@@ -136,9 +136,10 @@
         "hasc:id":"CU.AR.AL",
         "wd:id":"Q603163"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892246,
-    "wof:geomhash":"154d9cc61678f617e59f45c44640f80a",
+    "wof:geomhash":"6e369c0f1af1ee4b91c70e32e0b58ec9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1091902641,
-    "wof:lastmodified":1690868520,
+    "wof:lastmodified":1695887185,
     "wof:name":"Alquizar",
     "wof:parent_id":85670449,
     "wof:placetype":"county",

--- a/data/109/190/266/7/1091902667.geojson
+++ b/data/109/190/266/7/1091902667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075403,
-    "geom:area_square_m":871559311.677657,
+    "geom:area_square_m":871559075.559889,
     "geom:bbox":"-77.831005,20.667917,-77.459221,20.984965",
     "geom:latitude":20.807286,
     "geom:longitude":-77.63024,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"CU.LT.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892248,
-    "wof:geomhash":"41f43fb24b7b528f1c4c8e7d2ed4c21d",
+    "wof:geomhash":"2f2e8c1fa38ac0764f07db0bd22eb8dc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091902667,
-    "wof:lastmodified":1627507745,
+    "wof:lastmodified":1695886716,
     "wof:name":"Amancio Rodriguez",
     "wof:parent_id":85670439,
     "wof:placetype":"county",

--- a/data/109/190/271/3/1091902713.geojson
+++ b/data/109/190/271/3/1091902713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009902,
-    "geom:area_square_m":114428931.137058,
+    "geom:area_square_m":114428931.137021,
     "geom:bbox":"-75.7723746999,20.7776672808,-75.552886963,20.8958842017",
     "geom:latitude":20.846662,
     "geom:longitude":-75.660234,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892250,
-    "wof:geomhash":"fe98b78d9f60c1eb4801b63764c2bc5b",
+    "wof:geomhash":"ad3d7437f12868e9af38076a408f35f6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1091902713,
-    "wof:lastmodified":1564327956,
+    "wof:lastmodified":1695886597,
     "wof:name":"Antilla",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/273/7/1091902737.geojson
+++ b/data/109/190/273/7/1091902737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007086,
-    "geom:area_square_m":80645515.953029,
+    "geom:area_square_m":80645686.049891,
     "geom:bbox":"-82.38002,22.946096,-82.252353,23.091402",
     "geom:latitude":23.021189,
     "geom:longitude":-82.323348,
@@ -96,9 +96,10 @@
         "hasc:id":"CU.CH.AN",
         "wd:id":"Q1936053"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892251,
-    "wof:geomhash":"96398b71d59cee82a35936acc181f810",
+    "wof:geomhash":"253d8338799e21ed39f7e427e89b9c75",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1091902737,
-    "wof:lastmodified":1690868511,
+    "wof:lastmodified":1695886593,
     "wof:name":"Arroyo Naranjo",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/279/5/1091902795.geojson
+++ b/data/109/190/279/5/1091902795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060151,
-    "geom:area_square_m":685754438.53767,
+    "geom:area_square_m":685755215.944237,
     "geom:bbox":"-82.982568,22.594907,-82.650339,22.93563",
     "geom:latitude":22.780739,
     "geom:longitude":-82.817327,
@@ -234,9 +234,10 @@
         "hasc:id":"CU.AR.AR",
         "wd:id":"Q115006"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892253,
-    "wof:geomhash":"72041763a3788aa1dc78a875f54296ef",
+    "wof:geomhash":"633ecc4177df3b2dc98718cd7ec3fbaf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -246,7 +247,7 @@
         }
     ],
     "wof:id":1091902795,
-    "wof:lastmodified":1690868518,
+    "wof:lastmodified":1695886159,
     "wof:name":"Artemisa",
     "wof:parent_id":85670449,
     "wof:placetype":"county",

--- a/data/109/190/284/1/1091902841.geojson
+++ b/data/109/190/284/1/1091902841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06944,
-    "geom:area_square_m":802711259.32577,
+    "geom:area_square_m":802710850.268206,
     "geom:bbox":"-76.259737,20.616081,-75.852326,20.960195",
     "geom:latitude":20.792736,
     "geom:longitude":-76.038213,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892255,
-    "wof:geomhash":"b7b7471787073df24e0c7838da10980c",
+    "wof:geomhash":"8b8cabee84442799a44c30d521710fbe",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091902841,
-    "wof:lastmodified":1627507745,
+    "wof:lastmodified":1695886716,
     "wof:name":"Baguanos",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/287/3/1091902873.geojson
+++ b/data/109/190/287/3/1091902873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071071,
-    "geom:area_square_m":809578140.644137,
+    "geom:area_square_m":809578776.068348,
     "geom:bbox":"-83.397156,22.764841,-82.928203,23.01375",
     "geom:latitude":22.893344,
     "geom:longitude":-83.166711,
@@ -127,9 +127,10 @@
         "hasc:id":"CU.AR.BH",
         "wd:id":"Q571968"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892256,
-    "wof:geomhash":"1f861f7ea0fb1dbec0f7ad7aa92edfc9",
+    "wof:geomhash":"2b1376649c29128c810713024505b58a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1091902873,
-    "wof:lastmodified":1690868512,
+    "wof:lastmodified":1695887185,
     "wof:name":"Bahia Honda",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/291/5/1091902915.geojson
+++ b/data/109/190/291/5/1091902915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067077,
-    "geom:area_square_m":774481283.114551,
+    "geom:area_square_m":774481207.43172,
     "geom:bbox":"-75.901678,20.785701,-75.575417,21.136223",
     "geom:latitude":20.97091,
     "geom:longitude":-75.749067,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892258,
-    "wof:geomhash":"267ced83eb8da14d2ce0fadcb955a48c",
+    "wof:geomhash":"9bf92baa8d5bc1c6be6c3c443d7eaf3a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091902915,
-    "wof:lastmodified":1636504853,
+    "wof:lastmodified":1695886159,
     "wof:name":"Banes",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/296/1/1091902961.geojson
+++ b/data/109/190/296/1/1091902961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080854,
-    "geom:area_square_m":937435119.267433,
+    "geom:area_square_m":937435119.267113,
     "geom:bbox":"-74.7933437718,20.1650479235,-74.2840014605,20.5687977594",
     "geom:latitude":20.340155,
     "geom:longitude":-74.56915,
@@ -148,9 +148,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CA.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892259,
-    "wof:geomhash":"849338f30fa866825a800c4bb45101c4",
+    "wof:geomhash":"adc9d90ecc90181926b1b438a09a8852",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1091902961,
-    "wof:lastmodified":1564327968,
+    "wof:lastmodified":1695886598,
     "wof:name":"Baracoa",
     "wof:parent_id":85670425,
     "wof:placetype":"county",

--- a/data/109/190/298/7/1091902987.geojson
+++ b/data/109/190/298/7/1091902987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056979,
-    "geom:area_square_m":661639767.008083,
+    "geom:area_square_m":661639808.601723,
     "geom:bbox":"-77.080795,19.937615,-76.781932,20.270819",
     "geom:latitude":20.102222,
     "geom:longitude":-76.925236,
@@ -103,9 +103,10 @@
         "hasc:id":"CU.GR.BM",
         "wd:id":"Q809538"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892261,
-    "wof:geomhash":"7cb16c9d5d60328931aaf3a514b7406b",
+    "wof:geomhash":"cfdfa755d547fe89506faeca79d85d95",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091902987,
-    "wof:lastmodified":1690868520,
+    "wof:lastmodified":1695887185,
     "wof:name":"Bartolome Maso",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/303/5/1091903035.geojson
+++ b/data/109/190/303/5/1091903035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016689,
-    "geom:area_square_m":190326936.168394,
+    "geom:area_square_m":190326608.403623,
     "geom:bbox":"-82.372525,22.677055,-82.195435,22.823884",
     "geom:latitude":22.737201,
     "geom:longitude":-82.284209,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MQ.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892263,
-    "wof:geomhash":"d642fc905cbfc62def5cb7f120646b04",
+    "wof:geomhash":"74462c33bd7bf6d8df9e66e4c7d77337",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091903035,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886717,
     "wof:name":"Batabano",
     "wof:parent_id":85670461,
     "wof:placetype":"county",

--- a/data/109/190/307/5/1091903075.geojson
+++ b/data/109/190/307/5/1091903075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013583,
-    "geom:area_square_m":154626377.799031,
+    "geom:area_square_m":154626461.487965,
     "geom:bbox":"-82.598215,22.920124,-82.43605,23.07656",
     "geom:latitude":22.985917,
     "geom:longitude":-82.524062,
@@ -129,9 +129,10 @@
         "hasc:id":"CU.AR.BU",
         "wd:id":"Q114970"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892264,
-    "wof:geomhash":"5059882ec696f320676fb2cb4121db7d",
+    "wof:geomhash":"ae590d32aaa9a4cb5cf9ebc0ec7edb7e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1091903075,
-    "wof:lastmodified":1690868508,
+    "wof:lastmodified":1695887185,
     "wof:name":"Bauta",
     "wof:parent_id":85670449,
     "wof:placetype":"county",

--- a/data/109/190/310/5/1091903105.geojson
+++ b/data/109/190/310/5/1091903105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079143,
-    "geom:area_square_m":917212890.905436,
+    "geom:area_square_m":917213174.823766,
     "geom:bbox":"-76.86228,20.210681,-76.509813,20.579614",
     "geom:latitude":20.404216,
     "geom:longitude":-76.669277,
@@ -243,9 +243,10 @@
         "hasc:id":"CU.GR.BY",
         "wd:id":"Q115382"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892266,
-    "wof:geomhash":"52ef229fc09fd041818ff1b24137a25a",
+    "wof:geomhash":"0d9d7bdbf665b1546182ad24f0611732",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -255,7 +256,7 @@
         }
     ],
     "wof:id":1091903105,
-    "wof:lastmodified":1690868522,
+    "wof:lastmodified":1695886594,
     "wof:name":"Bayamo",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/314/7/1091903147.geojson
+++ b/data/109/190/314/7/1091903147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010685,
-    "geom:area_square_m":121698834.94558,
+    "geom:area_square_m":121698834.945603,
     "geom:bbox":"-82.4363966137,22.859803493,-82.2635582112,22.9739794257",
     "geom:latitude":22.913958,
     "geom:longitude":-82.347959,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MQ.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892268,
-    "wof:geomhash":"4b98cbf1cda340d8ec19c6fc51922b92",
+    "wof:geomhash":"fa829b4c8dc04c95ae2fe844ebd0c665",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091903147,
-    "wof:lastmodified":1564327948,
+    "wof:lastmodified":1695886597,
     "wof:name":"Bejucal",
     "wof:parent_id":85670461,
     "wof:placetype":"county",

--- a/data/109/190/318/1/1091903181.geojson
+++ b/data/109/190/318/1/1091903181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078135,
-    "geom:area_square_m":895282083.704406,
+    "geom:area_square_m":895282083.704337,
     "geom:bbox":"-78.5615007997,21.9259738145,-78.0697123196,22.2360086802",
     "geom:latitude":22.081383,
     "geom:longitude":-78.327877,
@@ -713,9 +713,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CA.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892269,
-    "wof:geomhash":"dfc49dafac4ce9cd4ced3156f96e1f34",
+    "wof:geomhash":"d47ade1b03d34b4d135aaaaab4c780cb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -725,7 +726,7 @@
         }
     ],
     "wof:id":1091903181,
-    "wof:lastmodified":1564327973,
+    "wof:lastmodified":1695886599,
     "wof:name":"Bolivia",
     "wof:parent_id":85670419,
     "wof:placetype":"county",

--- a/data/109/190/320/5/1091903205.geojson
+++ b/data/109/190/320/5/1091903205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011814,
-    "geom:area_square_m":134472315.939238,
+    "geom:area_square_m":134472355.433748,
     "geom:bbox":"-82.478874,22.932974,-82.316415,23.0798",
     "geom:latitude":22.997571,
     "geom:longitude":-82.39821,
@@ -108,9 +108,10 @@
         "hasc:id":"CU.CH.BO",
         "wd:id":"Q1936076"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892271,
-    "wof:geomhash":"1e446c384041d98867b4e5371888e1cd",
+    "wof:geomhash":"5a81d2366b876934ab0e149e037576f2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1091903205,
-    "wof:lastmodified":1690868521,
+    "wof:lastmodified":1695886594,
     "wof:name":"Boyeros",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/324/3/1091903243.geojson
+++ b/data/109/190/324/3/1091903243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036926,
-    "geom:area_square_m":428730894.903952,
+    "geom:area_square_m":428730894.903942,
     "geom:bbox":"-76.8128163458,20.0084255512,-76.5453733827,20.2809642355",
     "geom:latitude":20.119367,
     "geom:longitude":-76.711284,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GR.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892272,
-    "wof:geomhash":"7e18c4c87b52b21436d587e598832fd3",
+    "wof:geomhash":"c7ae559aabd97da84f8e9266d7e0e93c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1091903243,
-    "wof:lastmodified":1564327946,
+    "wof:lastmodified":1695886596,
     "wof:name":"Buey Arriba",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/328/5/1091903285.geojson
+++ b/data/109/190/328/5/1091903285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052034,
-    "geom:area_square_m":596060343.743538,
+    "geom:area_square_m":596060236.34905,
     "geom:bbox":"-79.653588,21.986143,-79.296237,22.253554",
     "geom:latitude":22.118384,
     "geom:longitude":-79.479509,
@@ -124,9 +124,10 @@
         "hasc:id":"CU.SS.CA",
         "wd:id":"Q862728"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892274,
-    "wof:geomhash":"88e663382c93cf4195d9e417bb513848",
+    "wof:geomhash":"58544344dd92ae9de29e38253abcfe67",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1091903285,
-    "wof:lastmodified":1690868522,
+    "wof:lastmodified":1695887185,
     "wof:name":"Cabaiguan",
     "wof:parent_id":85670413,
     "wof:placetype":"county",

--- a/data/109/190/332/1/1091903321.geojson
+++ b/data/109/190/332/1/1091903321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05722,
-    "geom:area_square_m":661688584.419506,
+    "geom:area_square_m":661688584.419541,
     "geom:bbox":"-76.6213989995,20.5916717588,-76.2515938913,20.8727259057",
     "geom:latitude":20.740187,
     "geom:longitude":-76.441589,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892275,
-    "wof:geomhash":"6091562f1bd1fc980cef91c367c202b3",
+    "wof:geomhash":"9d95f71695e9e663131b7ea4398c91f4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091903321,
-    "wof:lastmodified":1564327949,
+    "wof:lastmodified":1695886597,
     "wof:name":"Cacocum",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/336/7/1091903367.geojson
+++ b/data/109/190/336/7/1091903367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033293,
-    "geom:area_square_m":380075842.437484,
+    "geom:area_square_m":380075646.006411,
     "geom:bbox":"-79.667588,22.408771,-78.956276,22.811222",
     "geom:latitude":22.594804,
     "geom:longitude":-79.451551,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.VC.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892277,
-    "wof:geomhash":"24c571712b8ffd1753dd7b810b701bd8",
+    "wof:geomhash":"afdb1069b716f4e68c556cda86668e12",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091903367,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886717,
     "wof:name":"Caibarien",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/341/3/1091903413.geojson
+++ b/data/109/190/341/3/1091903413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036275,
-    "geom:area_square_m":421602461.276911,
+    "geom:area_square_m":421602461.276896,
     "geom:bbox":"-75.3537872762,19.881305695,-74.95375061,20.0671845788",
     "geom:latitude":19.962219,
     "geom:longitude":-75.140337,
@@ -95,9 +95,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GU.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892279,
-    "wof:geomhash":"8b707fc5d53ddfc1c6ae4dca258811d8",
+    "wof:geomhash":"88b920f02f4b8fbac7b37f3ba64b0347",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091903413,
-    "wof:lastmodified":1564327945,
+    "wof:lastmodified":1695886596,
     "wof:name":"Caimanera",
     "wof:parent_id":85670425,
     "wof:placetype":"county",

--- a/data/109/190/345/1/1091903451.geojson
+++ b/data/109/190/345/1/1091903451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02094,
-    "geom:area_square_m":238460736.255764,
+    "geom:area_square_m":238460402.081442,
     "geom:bbox":"-82.687478,22.802915,-82.561632,23.052084",
     "geom:latitude":22.93126,
     "geom:longitude":-82.624682,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"CU.AR.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892280,
-    "wof:geomhash":"055def12dc177c9d1dd3acf8874e0220",
+    "wof:geomhash":"e5b2d54094808933aa0534e00c40706e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1091903451,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886718,
     "wof:name":"Caimito",
     "wof:parent_id":85670449,
     "wof:placetype":"county",

--- a/data/109/190/349/5/1091903495.geojson
+++ b/data/109/190/349/5/1091903495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086447,
-    "geom:area_square_m":988104250.15434,
+    "geom:area_square_m":988104250.154151,
     "geom:bbox":"-81.0959446838,22.150519729,-80.6676198177,22.648576064",
     "geom:latitude":22.423843,
     "geom:longitude":-80.919752,
@@ -95,9 +95,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892282,
-    "wof:geomhash":"cacf6f698776ce0f3bcbc6a0167e388e",
+    "wof:geomhash":"00bc68c2421c17459d318ebeee4b61a2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091903495,
-    "wof:lastmodified":1564327947,
+    "wof:lastmodified":1695886596,
     "wof:name":"Calimete",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/354/1/1091903541.geojson
+++ b/data/109/190/354/1/1091903541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053287,
-    "geom:area_square_m":615707799.336612,
+    "geom:area_square_m":615707399.59065,
     "geom:bbox":"-76.72763,20.674083,-76.429624,21.03175",
     "geom:latitude":20.861866,
     "geom:longitude":-76.588656,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892284,
-    "wof:geomhash":"dee69897c79e4b60df10883852a7d6a5",
+    "wof:geomhash":"b891de17f7b0a74aef83bb5c63570a54",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091903541,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886718,
     "wof:name":"Calixto Garcia",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/357/7/1091903577.geojson
+++ b/data/109/190/357/7/1091903577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10416,
-    "geom:area_square_m":1198922871.165862,
+    "geom:area_square_m":1198922559.447291,
     "geom:bbox":"-78.192855,21.198717,-77.661719,21.633024",
     "geom:latitude":21.428944,
     "geom:longitude":-77.92616,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892286,
-    "wof:geomhash":"28bb84c9d69735d7d335398d49aa75d6",
+    "wof:geomhash":"03c5c46f54fbde1d879af5176d23e3fa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091903577,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886718,
     "wof:name":"Camaguey",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/363/3/1091903633.geojson
+++ b/data/109/190/363/3/1091903633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052869,
-    "geom:area_square_m":603858629.583591,
+    "geom:area_square_m":603858586.471018,
     "geom:bbox":"-79.875539,22.36735,-79.584005,22.748132",
     "geom:latitude":22.526376,
     "geom:longitude":-79.706894,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.VC.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892288,
-    "wof:geomhash":"66e6dac0a2f6c743d61dd804ba5bc1a0",
+    "wof:geomhash":"adf9c65854fde8f710c18c53d885ded8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091903633,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886718,
     "wof:name":"Camajuani",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/367/3/1091903673.geojson
+++ b/data/109/190/367/3/1091903673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048516,
-    "geom:area_square_m":563297246.088898,
+    "geom:area_square_m":563297246.088795,
     "geom:bbox":"-77.4078232999,19.9921747193,-77.0627220539,20.293750763",
     "geom:latitude":20.120057,
     "geom:longitude":-77.225485,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GR.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892289,
-    "wof:geomhash":"98448846813966bffda1883c6007bd89",
+    "wof:geomhash":"80dcbbdd35e824f6dd10ba810dc1749a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1091903673,
-    "wof:lastmodified":1564327950,
+    "wof:lastmodified":1695886597,
     "wof:name":"Campechuela",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/370/5/1091903705.geojson
+++ b/data/109/190/370/5/1091903705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024136,
-    "geom:area_square_m":275229571.704888,
+    "geom:area_square_m":275229571.704907,
     "geom:bbox":"-83.103768809,22.5725403095,-82.8335829728,22.8749642037",
     "geom:latitude":22.747306,
     "geom:longitude":-82.96331,
@@ -119,9 +119,10 @@
     "wof:concordances":{
         "hasc:id":"CU.AR.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892291,
-    "wof:geomhash":"c493b55cc32f9af665b32dac7237fb3f",
+    "wof:geomhash":"300fddae6c8fe6c105a2f79bef294d59",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1091903705,
-    "wof:lastmodified":1564327946,
+    "wof:lastmodified":1695886596,
     "wof:name":"Candelaria",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/374/9/1091903749.geojson
+++ b/data/109/190/374/9/1091903749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050852,
-    "geom:area_square_m":578747738.663198,
+    "geom:area_square_m":578748088.223997,
     "geom:bbox":"-81.491136,22.829607,-81.04928,23.139283",
     "geom:latitude":23.013012,
     "geom:longitude":-81.256092,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892293,
-    "wof:geomhash":"f072784d3e63fdff22ec955458dcaed1",
+    "wof:geomhash":"8ad7dc12b7f5c26eb0452ab2376fe1fe",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091903749,
-    "wof:lastmodified":1636504853,
+    "wof:lastmodified":1695886159,
     "wof:name":"Cardenas",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/379/3/1091903793.geojson
+++ b/data/109/190/379/3/1091903793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058003,
-    "geom:area_square_m":666511068.601314,
+    "geom:area_square_m":666510903.553856,
     "geom:bbox":"-78.450918,21.51705,-78.102241,21.821389",
     "geom:latitude":21.672866,
     "geom:longitude":-78.262051,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.CC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892294,
-    "wof:geomhash":"e321497e69d20c674d590fe428412840",
+    "wof:geomhash":"95e313e8c7b17c1f7dbc00926a570dc8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091903793,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886718,
     "wof:name":"Carlos Manuel De Cespedes",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/382/1/1091903821.geojson
+++ b/data/109/190/382/1/1091903821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047608,
-    "geom:area_square_m":551059581.265553,
+    "geom:area_square_m":551059581.265526,
     "geom:bbox":"-76.7932503042,20.454051838,-76.3673804677,20.7331845846",
     "geom:latitude":20.596446,
     "geom:longitude":-76.580284,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GR.CC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892296,
-    "wof:geomhash":"3d732b8b9a7a824e9c41df87f39687dc",
+    "wof:geomhash":"d98791d1c2f70d5f18598cf2738927a9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1091903821,
-    "wof:lastmodified":1564327947,
+    "wof:lastmodified":1695886597,
     "wof:name":"Cauto Cristo",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/386/3/1091903863.geojson
+++ b/data/109/190/386/3/1091903863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000889,
-    "geom:area_square_m":10111246.520663,
+    "geom:area_square_m":10111357.513813,
     "geom:bbox":"-82.405604,23.076702,-82.365783,23.128021",
     "geom:latitude":23.099859,
     "geom:longitude":-82.384462,
@@ -114,9 +114,10 @@
         "hasc:id":"CU.CH.CE",
         "wd:id":"Q1055715"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892297,
-    "wof:geomhash":"e44e3f98ff1310ceb6f4671544328356",
+    "wof:geomhash":"b40aff5a807a6cd46418f3973e4d9375",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1091903863,
-    "wof:lastmodified":1690868522,
+    "wof:lastmodified":1695887185,
     "wof:name":"Cerro",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/390/5/1091903905.geojson
+++ b/data/109/190/390/5/1091903905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102052,
-    "geom:area_square_m":1167301670.644697,
+    "geom:area_square_m":1167301670.644738,
     "geom:bbox":"-79.0320877778,22.0904357948,-78.271247864,22.61536026",
     "geom:latitude":22.325623,
     "geom:longitude":-78.723477,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CA.FL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892299,
-    "wof:geomhash":"eaa825a39cba11eb17e5f55982d64d28",
+    "wof:geomhash":"b1639be9939ab5074f57b32d393a573b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091903905,
-    "wof:lastmodified":1564327936,
+    "wof:lastmodified":1695886595,
     "wof:name":"Chambas",
     "wof:parent_id":85670419,
     "wof:placetype":"county",

--- a/data/109/190/394/7/1091903947.geojson
+++ b/data/109/190/394/7/1091903947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03763,
-    "geom:area_square_m":431801492.47794,
+    "geom:area_square_m":431801347.000922,
     "geom:bbox":"-78.901787,21.762767,-78.647675,21.992533",
     "geom:latitude":21.87609,
     "geom:longitude":-78.758513,
@@ -222,9 +222,10 @@
         "hasc:id":"CU.CA.CA",
         "wd:id":"Q115465"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892300,
-    "wof:geomhash":"edf880ad5c29c1f014a9f80c3d34db9f",
+    "wof:geomhash":"eb0c05b669d429be293f2272b8279517",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -234,7 +235,7 @@
         }
     ],
     "wof:id":1091903947,
-    "wof:lastmodified":1690868517,
+    "wof:lastmodified":1695886594,
     "wof:name":"Ciego De Avila",
     "wof:parent_id":85670419,
     "wof:placetype":"county",

--- a/data/109/190/398/7/1091903987.geojson
+++ b/data/109/190/398/7/1091903987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.364713,
-    "geom:area_square_m":4172196761.734388,
+    "geom:area_square_m":4172196882.306244,
     "geom:bbox":"-82.159637,22.018749,-80.590207,22.613025",
     "geom:latitude":22.308622,
     "geom:longitude":-81.416821,
@@ -124,9 +124,10 @@
         "hasc:id":"CU.MA.CZ",
         "wd:id":"Q5951909"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892302,
-    "wof:geomhash":"c4de09a344450a22d098bbedc342eace",
+    "wof:geomhash":"939a523c0bb9d54f0441d9f9e26ce7f3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1091903987,
-    "wof:lastmodified":1690868508,
+    "wof:lastmodified":1695886592,
     "wof:name":"Cienaga De Zapata",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/403/5/1091904035.geojson
+++ b/data/109/190/403/5/1091904035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038315,
-    "geom:area_square_m":438854628.720711,
+    "geom:area_square_m":438854897.468554,
     "geom:bbox":"-80.567889,22.024166,-80.267584,22.231628",
     "geom:latitude":22.136567,
     "geom:longitude":-80.422592,
@@ -280,9 +280,10 @@
         "hasc:id":"CU.CF.CI",
         "wd:id":"Q190005"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892304,
-    "wof:geomhash":"101372ad196d1c3ec0160bce0dabf685",
+    "wof:geomhash":"dfe71249023114d9fbda755ba290b86d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -292,7 +293,7 @@
         }
     ],
     "wof:id":1091904035,
-    "wof:lastmodified":1690868521,
+    "wof:lastmodified":1695886159,
     "wof:name":"Cienfuegos",
     "wof:parent_id":85670403,
     "wof:placetype":"county",

--- a/data/109/190/406/9/1091904069.geojson
+++ b/data/109/190/406/9/1091904069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045364,
-    "geom:area_square_m":517814750.411636,
+    "geom:area_square_m":517814750.411645,
     "geom:bbox":"-80.1498787044,22.478393913,-79.8340076702,22.7516673873",
     "geom:latitude":22.613563,
     "geom:longitude":-80.00906,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"CU.VC.CI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892305,
-    "wof:geomhash":"181a34b742558ac56b0bf482052af8c7",
+    "wof:geomhash":"f9fd98edd041d5ba0352961d07199016",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1091904069,
-    "wof:lastmodified":1564327943,
+    "wof:lastmodified":1695886596,
     "wof:name":"Cifuentes",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/408/5/1091904085.geojson
+++ b/data/109/190/408/5/1091904085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051192,
-    "geom:area_square_m":586941304.581046,
+    "geom:area_square_m":586941304.581129,
     "geom:bbox":"-78.8517026769,21.7744092958,-78.4966023769,22.166997777",
     "geom:latitude":21.991207,
     "geom:longitude":-78.678804,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CA.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892307,
-    "wof:geomhash":"3d109a1faa59941430fb7b0ccf39c191",
+    "wof:geomhash":"dc91ad827888fd701d35bb2e1178022c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091904085,
-    "wof:lastmodified":1564327943,
+    "wof:lastmodified":1695886596,
     "wof:name":"Ciro Redondo",
     "wof:parent_id":85670419,
     "wof:placetype":"county",

--- a/data/109/190/411/5/1091904115.geojson
+++ b/data/109/190/411/5/1091904115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049207,
-    "geom:area_square_m":568548983.31283,
+    "geom:area_square_m":568548983.312829,
     "geom:bbox":"-77.5341917784,20.6801083119,-77.3213740362,21.0853136017",
     "geom:latitude":20.866324,
     "geom:longitude":-77.418684,
@@ -749,9 +749,10 @@
     "wof:concordances":{
         "hasc:id":"CU.LT.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892309,
-    "wof:geomhash":"b1311634bdf94ff76a3252f2b955a7de",
+    "wof:geomhash":"eb1dc4e722f21e2059daa99cdd680bcf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -761,7 +762,7 @@
         }
     ],
     "wof:id":1091904115,
-    "wof:lastmodified":1564327956,
+    "wof:lastmodified":1695886597,
     "wof:name":"Colombia",
     "wof:parent_id":85670439,
     "wof:placetype":"county",

--- a/data/109/190/414/3/1091904143.geojson
+++ b/data/109/190/414/3/1091904143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052739,
-    "geom:area_square_m":601405721.635585,
+    "geom:area_square_m":601405721.635575,
     "geom:bbox":"-81.0539705255,22.6170937417,-80.7158191284,22.897300767",
     "geom:latitude":22.747363,
     "geom:longitude":-80.878165,
@@ -118,9 +118,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892311,
-    "wof:geomhash":"ce38dac8033b6057e8c45a016c6da457",
+    "wof:geomhash":"046f9611b30e683da1ee62bb3aa2bb7f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1091904143,
-    "wof:lastmodified":1564327939,
+    "wof:lastmodified":1695886595,
     "wof:name":"Colon",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/417/5/1091904175.geojson
+++ b/data/109/190/417/5/1091904175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095813,
-    "geom:area_square_m":1095030276.18504,
+    "geom:area_square_m":1095030686.812041,
     "geom:bbox":"-83.665911,22.18375,-83.275777,22.646809",
     "geom:latitude":22.440378,
     "geom:longitude":-83.437662,
@@ -106,9 +106,10 @@
         "hasc:id":"CU.PD.CS",
         "wd:id":"Q1127452"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892312,
-    "wof:geomhash":"7afb9b7e015fe1a896228c33b66e46ec",
+    "wof:geomhash":"fff5e6d127378724539e6d1c0073f263",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091904175,
-    "wof:lastmodified":1690868518,
+    "wof:lastmodified":1695887185,
     "wof:name":"Consolacion Del Sur",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/422/1/1091904221.geojson
+++ b/data/109/190/422/1/1091904221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052288,
-    "geom:area_square_m":606369552.944722,
+    "geom:area_square_m":606369474.600773,
     "geom:bbox":"-76.393701,20.161474,-76.067881,20.462387",
     "geom:latitude":20.306585,
     "geom:longitude":-76.231159,
@@ -123,9 +123,10 @@
         "hasc:id":"CU.SC.CO",
         "wd:id":"Q1129122"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892314,
-    "wof:geomhash":"5d09ffe9a8b696ca376208fedc8c6fd4",
+    "wof:geomhash":"a8d2be1cbaa457b8755fa3b20aa40cd4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1091904221,
-    "wof:lastmodified":1690868511,
+    "wof:lastmodified":1695886593,
     "wof:name":"Contramaestre",
     "wof:parent_id":85670441,
     "wof:placetype":"county",

--- a/data/109/190/425/1/1091904251.geojson
+++ b/data/109/190/425/1/1091904251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074637,
-    "geom:area_square_m":850242302.094217,
+    "geom:area_square_m":850242302.094231,
     "geom:bbox":"-80.7544314133,22.7311252947,-80.3209833664,23.066223145",
     "geom:latitude":22.888126,
     "geom:longitude":-80.536054,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"CU.VC.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892315,
-    "wof:geomhash":"8ef8597c231704b6bc43275626682365",
+    "wof:geomhash":"dc2f362963db535f2a349e2982dadf83",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091904251,
-    "wof:lastmodified":1564327938,
+    "wof:lastmodified":1695886595,
     "wof:name":"Corralillo",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/428/3/1091904283.geojson
+++ b/data/109/190/428/3/1091904283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006618,
-    "geom:area_square_m":75318612.531773,
+    "geom:area_square_m":75318612.531798,
     "geom:bbox":"-82.3121059735,22.9733414417,-82.204814001,23.080302548",
     "geom:latitude":23.025172,
     "geom:longitude":-82.259811,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CH.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892317,
-    "wof:geomhash":"9b5a65e24cf6455193c024a60b39aae9",
+    "wof:geomhash":"49e799bdad335e490325de6b9e27240c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091904283,
-    "wof:lastmodified":1564327951,
+    "wof:lastmodified":1695886597,
     "wof:name":"Cotorro",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/432/9/1091904329.geojson
+++ b/data/109/190/432/9/1091904329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016774,
-    "geom:area_square_m":191902388.792849,
+    "geom:area_square_m":191902413.991968,
     "geom:bbox":"-80.334044,22.222065,-80.09623,22.383492",
     "geom:latitude":22.295042,
     "geom:longitude":-80.220619,
@@ -114,9 +114,10 @@
         "hasc:id":"CU.CF.CR",
         "wd:id":"Q5042"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892318,
-    "wof:geomhash":"2c8f19519d77ad2cf66bcb5397df5be3",
+    "wof:geomhash":"bd7b168c7223734b0da641ac246851f7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1091904329,
-    "wof:lastmodified":1690868520,
+    "wof:lastmodified":1695887185,
     "wof:name":"Cruces",
     "wof:parent_id":85670403,
     "wof:placetype":"county",

--- a/data/109/190/436/1/1091904361.geojson
+++ b/data/109/190/436/1/1091904361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027917,
-    "geom:area_square_m":323163002.178871,
+    "geom:area_square_m":323163115.648147,
     "geom:bbox":"-76.027853,20.456906,-75.803208,20.704976",
     "geom:latitude":20.583026,
     "geom:longitude":-75.922696,
@@ -105,9 +105,10 @@
         "hasc:id":"CU.HO.CU",
         "wd:id":"Q280984"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892320,
-    "wof:geomhash":"7b24d09b03f202ee8660ba3ce712e0a2",
+    "wof:geomhash":"acb4eec10ebd1bec743f0447955d8a9f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091904361,
-    "wof:lastmodified":1690868513,
+    "wof:lastmodified":1695886593,
     "wof:name":"Cueto",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/438/5/1091904385.geojson
+++ b/data/109/190/438/5/1091904385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096411,
-    "geom:area_square_m":1105061806.255978,
+    "geom:area_square_m":1105061773.52965,
     "geom:bbox":"-80.412086,21.818494,-80.02873,22.270734",
     "geom:latitude":22.034447,
     "geom:longitude":-80.197151,
@@ -120,9 +120,10 @@
         "hasc:id":"CU.CF.CU",
         "wd:id":"Q5044"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892321,
-    "wof:geomhash":"59634f8f015dca237c30e08bd26f15eb",
+    "wof:geomhash":"e0f34a6a44761d72bacd0c55bcadde66",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1091904385,
-    "wof:lastmodified":1690868514,
+    "wof:lastmodified":1695886593,
     "wof:name":"Cumanayagua",
     "wof:parent_id":85670403,
     "wof:placetype":"county",

--- a/data/109/190/442/1/1091904421.geojson
+++ b/data/109/190/442/1/1091904421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000986,
-    "geom:area_square_m":11216747.811148,
+    "geom:area_square_m":11216446.37633,
     "geom:bbox":"-82.381746,23.07998,-82.336999,23.11561",
     "geom:latitude":23.096026,
     "geom:longitude":-82.360186,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CH.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892323,
-    "wof:geomhash":"602662d8447eb34f2b049a77521a3382",
+    "wof:geomhash":"bfcd38c09d4cd6384fe595b64df8d2d7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091904421,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886718,
     "wof:name":"Diez De Octubre",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/445/9/1091904459.geojson
+++ b/data/109/190/445/9/1091904459.geojson
@@ -626,9 +626,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GU.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892324,
-    "wof:geomhash":"82d0977a970f53e05d7f5e7579c52189",
+    "wof:geomhash":"ff8371e5c68879c02adc5f1de5bd71c1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -638,7 +639,7 @@
         }
     ],
     "wof:id":1091904459,
-    "wof:lastmodified":1564327960,
+    "wof:lastmodified":1695886597,
     "wof:name":"El Salvador",
     "wof:parent_id":85670425,
     "wof:placetype":"county",

--- a/data/109/190/448/3/1091904483.geojson
+++ b/data/109/190/448/3/1091904483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052937,
-    "geom:area_square_m":603854623.149571,
+    "geom:area_square_m":603854623.149572,
     "geom:bbox":"-79.9480729827,22.5311165667,-79.6460691716,22.905416489",
     "geom:latitude":22.703143,
     "geom:longitude":-79.81938,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"CU.VC.EN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892326,
-    "wof:geomhash":"8edc618095d846b235b7bae28422fbfc",
+    "wof:geomhash":"4f029cce116cdd05d88369ee38a75bc7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091904483,
-    "wof:lastmodified":1564327940,
+    "wof:lastmodified":1695886595,
     "wof:name":"Encrucijada",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/451/7/1091904517.geojson
+++ b/data/109/190/451/7/1091904517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.141511,
-    "geom:area_square_m":1623741437.375259,
+    "geom:area_square_m":1623741437.375249,
     "geom:bbox":"-78.2624522871,21.6169946228,-77.620414734,22.1120256127",
     "geom:latitude":21.881527,
     "geom:longitude":-77.945269,
@@ -122,9 +122,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892328,
-    "wof:geomhash":"a8c5674d2acb3167eee16f8eabcb54fe",
+    "wof:geomhash":"cb281f3a50d80b2f3f93435b84e425d6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1091904517,
-    "wof:lastmodified":1564327966,
+    "wof:lastmodified":1695886598,
     "wof:name":"Esmeralda",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/455/7/1091904557.geojson
+++ b/data/109/190/455/7/1091904557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025974,
-    "geom:area_square_m":297598800.974575,
+    "geom:area_square_m":297598800.974568,
     "geom:bbox":"-79.0570162852,21.9891607995,-78.8294539978,22.1790935629",
     "geom:latitude":22.088347,
     "geom:longitude":-78.93626,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CA.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892329,
-    "wof:geomhash":"cdd4cd12b56a22100f2f24089e4ddecc",
+    "wof:geomhash":"593f1c8b709a81fe1548b8c5c21efbb2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1091904557,
-    "wof:lastmodified":1564327944,
+    "wof:lastmodified":1695886596,
     "wof:name":"Florencia",
     "wof:parent_id":85670419,
     "wof:placetype":"county",

--- a/data/109/190/458/5/1091904585.geojson
+++ b/data/109/190/458/5/1091904585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147852,
-    "geom:area_square_m":1701226616.748854,
+    "geom:area_square_m":1701226616.74909,
     "geom:bbox":"-78.6495460649,21.2737789893,-77.9662289804,21.7344221623",
     "geom:latitude":21.480736,
     "geom:longitude":-78.320635,
@@ -572,9 +572,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.FL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892331,
-    "wof:geomhash":"dd0820f268a6ba82c7edff29fb348f86",
+    "wof:geomhash":"25ce1f6480834221152c1c6a2db381d7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -584,7 +585,7 @@
         }
     ],
     "wof:id":1091904585,
-    "wof:lastmodified":1564327964,
+    "wof:lastmodified":1695886598,
     "wof:name":"Florida",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/462/3/1091904623.geojson
+++ b/data/109/190/462/3/1091904623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040725,
-    "geom:area_square_m":466726295.252236,
+    "geom:area_square_m":466726315.00385,
     "geom:bbox":"-79.805072,21.892072,-79.546485,22.212821",
     "geom:latitude":22.052521,
     "geom:longitude":-79.691442,
@@ -105,9 +105,10 @@
         "hasc:id":"CU.SS.FO",
         "wd:id":"Q861489"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892333,
-    "wof:geomhash":"2fc664820761225ef304507f651ffc6d",
+    "wof:geomhash":"c825b620a4b59e2ee02b6639ab1f84a1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091904623,
-    "wof:lastmodified":1690868515,
+    "wof:lastmodified":1695887185,
     "wof:name":"Fomento",
     "wof:parent_id":85670413,
     "wof:placetype":"county",

--- a/data/109/190/466/1/1091904661.geojson
+++ b/data/109/190/466/1/1091904661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043855,
-    "geom:area_square_m":507434818.10984,
+    "geom:area_square_m":507434138.672467,
     "geom:bbox":"-75.486124,20.538216,-75.001738,20.745417",
     "geom:latitude":20.651983,
     "geom:longitude":-75.286053,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.FP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892334,
-    "wof:geomhash":"e595716a3894d9d3558dc71f667baddd",
+    "wof:geomhash":"a67cf8ab637d17c864526038252f90e4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091904661,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886718,
     "wof:name":"Frank Pais",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/469/3/1091904693.geojson
+++ b/data/109/190/469/3/1091904693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054402,
-    "geom:area_square_m":627631693.2342,
+    "geom:area_square_m":627631693.234097,
     "geom:bbox":"-76.4809995371,20.97141356,-76.0726342166,21.2457837472",
     "geom:latitude":21.090162,
     "geom:longitude":-76.279446,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892336,
-    "wof:geomhash":"68a4f4c5cfb3208e04ab5767664823c8",
+    "wof:geomhash":"d4fcb23012d37f5affac8f8a9737ce9d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091904693,
-    "wof:lastmodified":1564327965,
+    "wof:lastmodified":1695886598,
     "wof:name":"Gibara",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/472/5/1091904725.geojson
+++ b/data/109/190/472/5/1091904725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161177,
-    "geom:area_square_m":1857632988.550592,
+    "geom:area_square_m":1857632788.832309,
     "geom:bbox":"-77.62667,20.961967,-77.079433,21.522171",
     "geom:latitude":21.237264,
     "geom:longitude":-77.329424,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892337,
-    "wof:geomhash":"041eb3c89904e35e066650a62b352397",
+    "wof:geomhash":"8ea70d5205eb68ee26be771f516821b2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091904725,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886718,
     "wof:name":"Guaimaro",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/476/5/1091904765.geojson
+++ b/data/109/190/476/5/1091904765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083307,
-    "geom:area_square_m":968031113.013418,
+    "geom:area_square_m":968031113.013457,
     "geom:bbox":"-77.0567747499,19.885389328,-75.9505390362,20.0928400738",
     "geom:latitude":19.992915,
     "geom:longitude":-76.53112,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"CU.SC.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892339,
-    "wof:geomhash":"10b5222bd00140897ff82538757c7a02",
+    "wof:geomhash":"b3fe398b7d6f6e3d68ba130d83677dd0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091904765,
-    "wof:lastmodified":1564327938,
+    "wof:lastmodified":1695886595,
     "wof:name":"Guama",
     "wof:parent_id":85670441,
     "wof:placetype":"county",

--- a/data/109/190/480/3/1091904803.geojson
+++ b/data/109/190/480/3/1091904803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010925,
-    "geom:area_square_m":124253032.584473,
+    "geom:area_square_m":124253032.584434,
     "geom:bbox":"-82.3270580603,23.0527936677,-82.1587826409,23.161509813",
     "geom:latitude":23.108695,
     "geom:longitude":-82.231043,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CH.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892340,
-    "wof:geomhash":"80c0ac3959c6a6dab03622b6d903dc1e",
+    "wof:geomhash":"7b75b7c78f49a4437717b0f35d025fbb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091904803,
-    "wof:lastmodified":1564327957,
+    "wof:lastmodified":1695886597,
     "wof:name":"Guanabacoa",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/482/7/1091904827.geojson
+++ b/data/109/190/482/7/1091904827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010213,
-    "geom:area_square_m":116329326.012185,
+    "geom:area_square_m":116329194.964777,
     "geom:bbox":"-82.827486,22.862108,-82.654989,22.971991",
     "geom:latitude":22.907098,
     "geom:longitude":-82.72981,
@@ -135,9 +135,10 @@
         "hasc:id":"CU.AR.GJ",
         "wd:id":"Q114977"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892342,
-    "wof:geomhash":"f35d24280bbaca388091cf4c68380351",
+    "wof:geomhash":"082e85c57a1ed108a9d5d0c4ef2d74d6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1091904827,
-    "wof:lastmodified":1690868511,
+    "wof:lastmodified":1695886593,
     "wof:name":"Guanajay",
     "wof:parent_id":85670449,
     "wof:placetype":"county",

--- a/data/109/190/487/3/1091904873.geojson
+++ b/data/109/190/487/3/1091904873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062942,
-    "geom:area_square_m":720279698.926589,
+    "geom:area_square_m":720279767.866851,
     "geom:bbox":"-84.229627,22.085335,-83.933264,22.467956",
     "geom:latitude":22.261424,
     "geom:longitude":-84.065751,
@@ -108,9 +108,10 @@
         "hasc:id":"CU.PD.GU",
         "wd:id":"Q535537"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892343,
-    "wof:geomhash":"5b5711960ff54480691b6c1f7739038d",
+    "wof:geomhash":"79ee616cb602b1495783a5b0d0346468",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1091904873,
-    "wof:lastmodified":1690868519,
+    "wof:lastmodified":1695886594,
     "wof:name":"Guane",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/491/9/1091904919.geojson
+++ b/data/109/190/491/9/1091904919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064206,
-    "geom:area_square_m":744828138.061844,
+    "geom:area_square_m":744828125.317182,
     "geom:bbox":"-75.258591,20.018104,-75.049337,20.479123",
     "geom:latitude":20.254945,
     "geom:longitude":-75.156472,
@@ -291,9 +291,10 @@
         "hasc:id":"CU.GU.GU",
         "wd:id":"Q185156"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892345,
-    "wof:geomhash":"9378765efad1873aa5a87cf7bddfa1a8",
+    "wof:geomhash":"96d38181d39dfda27487c9e7c0259fc5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -303,7 +304,7 @@
         }
     ],
     "wof:id":1091904919,
-    "wof:lastmodified":1690868514,
+    "wof:lastmodified":1695886593,
     "wof:name":"Guantanamo",
     "wof:parent_id":85670425,
     "wof:placetype":"county",

--- a/data/109/190/495/5/1091904955.geojson
+++ b/data/109/190/495/5/1091904955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040959,
-    "geom:area_square_m":466868409.611797,
+    "geom:area_square_m":466868409.611651,
     "geom:bbox":"-82.143214706,22.654556274,-81.8444317122,22.938963923",
     "geom:latitude":22.806995,
     "geom:longitude":-81.999707,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MQ.GS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892346,
-    "wof:geomhash":"fdb05b0022631ddb33a22be50ddb7a82",
+    "wof:geomhash":"db91e11fc4a98000a3231793360ad8ae",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1091904955,
-    "wof:lastmodified":1564327969,
+    "wof:lastmodified":1695886598,
     "wof:name":"Guines",
     "wof:parent_id":85670461,
     "wof:placetype":"county",

--- a/data/109/190/500/3/1091905003.geojson
+++ b/data/109/190/500/3/1091905003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016955,
-    "geom:area_square_m":193357106.740924,
+    "geom:area_square_m":193356797.630614,
     "geom:bbox":"-82.569185,22.54789,-82.430933,22.850679",
     "geom:latitude":22.737529,
     "geom:longitude":-82.502218,
@@ -113,9 +113,10 @@
         "hasc:id":"CU.AR.GM",
         "wd:id":"Q603115"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892348,
-    "wof:geomhash":"f006bff0ece54a31dab6d98b288f94da",
+    "wof:geomhash":"7555f25cd45fd2495c3d9ec7badb82b9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1091905003,
-    "wof:lastmodified":1690868517,
+    "wof:lastmodified":1695887185,
     "wof:name":"Guira De Melena",
     "wof:parent_id":85670449,
     "wof:placetype":"county",

--- a/data/109/190/503/9/1091905039.geojson
+++ b/data/109/190/503/9/1091905039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051717,
-    "geom:area_square_m":600270112.208792,
+    "geom:area_square_m":600270112.208739,
     "geom:bbox":"-76.6682498729,20.0409557095,-76.390593928,20.3081912901",
     "geom:latitude":20.17024,
     "geom:longitude":-76.528359,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GR.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892350,
-    "wof:geomhash":"f1aac9dc0d89c40e772d99b4152e4a7a",
+    "wof:geomhash":"9909c710ae8d51d31fd112af416de4ab",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091905039,
-    "wof:lastmodified":1564327935,
+    "wof:lastmodified":1695886595,
     "wof:name":"Guisa",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/507/3/1091905073.geojson
+++ b/data/109/190/507/3/1091905073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013165,
-    "geom:area_square_m":149696324.134368,
+    "geom:area_square_m":149695918.982265,
     "geom:bbox":"-82.359949,23.054584,-82.074825,23.18125",
     "geom:latitude":23.136157,
     "geom:longitude":-82.178549,
@@ -109,9 +109,10 @@
         "hasc:id":"CU.CH.HE",
         "wd:id":"Q1566695"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892351,
-    "wof:geomhash":"dbccaa7ef9c655bf72016dbcd504dc67",
+    "wof:geomhash":"2b22e1723407c4af68f1a60b2abcee90",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1091905073,
-    "wof:lastmodified":1690868517,
+    "wof:lastmodified":1695887185,
     "wof:name":"Habana Del Este",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/511/7/1091905117.geojson
+++ b/data/109/190/511/7/1091905117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057617,
-    "geom:area_square_m":665572514.921935,
+    "geom:area_square_m":665573054.019406,
     "geom:bbox":"-76.471831,20.763,-76.096216,21.013258",
     "geom:latitude":20.899595,
     "geom:longitude":-76.280957,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892353,
-    "wof:geomhash":"99f394ab07f0fbc1ce064bc29970545e",
+    "wof:geomhash":"715bdd1c17ac9780a7c5a51edca37363",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091905117,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886718,
     "wof:name":"Holguin",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/515/3/1091905153.geojson
+++ b/data/109/190/515/3/1091905153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047004,
-    "geom:area_square_m":545685292.966657,
+    "geom:area_square_m":545684860.60943,
     "geom:bbox":"-74.740875,20.039557,-74.426586,20.280292",
     "geom:latitude":20.138161,
     "geom:longitude":-74.588091,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GU.IM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892354,
-    "wof:geomhash":"aae66a7619aa0587258807863746d295",
+    "wof:geomhash":"d6686e118d50523664fd834862c20b04",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091905153,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886718,
     "wof:name":"Imias",
     "wof:parent_id":85670425,
     "wof:placetype":"county",

--- a/data/109/190/519/5/1091905195.geojson
+++ b/data/109/190/519/5/1091905195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077858,
-    "geom:area_square_m":888860560.164784,
+    "geom:area_square_m":888860444.265137,
     "geom:bbox":"-81.350489,22.422136,-80.93201,22.795443",
     "geom:latitude":22.589941,
     "geom:longitude":-81.122461,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.JG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892356,
-    "wof:geomhash":"3d602e505d88a76941979fb34dee0db8",
+    "wof:geomhash":"fb21e22b600de22b078c789838497526",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091905195,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886718,
     "wof:name":"Jaguey Grande",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/523/3/1091905233.geojson
+++ b/data/109/190/523/3/1091905233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023267,
-    "geom:area_square_m":264705988.028719,
+    "geom:area_square_m":264705988.028732,
     "geom:bbox":"-82.1229065277,22.9754031202,-81.87274724,23.1564849563",
     "geom:latitude":23.061598,
     "geom:longitude":-82.002483,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MQ.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892358,
-    "wof:geomhash":"74fa3783641f6f098b6ef39141c6b56c",
+    "wof:geomhash":"4d9342bae9ccaff2a12ce3c027807bda",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091905233,
-    "wof:lastmodified":1564327975,
+    "wof:lastmodified":1695886599,
     "wof:name":"Jaruco",
     "wof:parent_id":85670461,
     "wof:placetype":"county",

--- a/data/109/190/528/3/1091905283.geojson
+++ b/data/109/190/528/3/1091905283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067609,
-    "geom:area_square_m":775459006.647796,
+    "geom:area_square_m":775458960.742285,
     "geom:bbox":"-79.266009,21.721223,-78.961167,22.154305",
     "geom:latitude":21.938472,
     "geom:longitude":-79.123939,
@@ -111,9 +111,10 @@
         "hasc:id":"CU.SS.JA",
         "wd:id":"Q861575"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892359,
-    "wof:geomhash":"9a2897471193e455ac8462902b0deedb",
+    "wof:geomhash":"ef358bed817b148d0da08ba7ce67b78b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1091905283,
-    "wof:lastmodified":1690868515,
+    "wof:lastmodified":1695887185,
     "wof:name":"Jatibonico",
     "wof:parent_id":85670413,
     "wof:placetype":"county",

--- a/data/109/190/531/5/1091905315.geojson
+++ b/data/109/190/531/5/1091905315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.157853,
-    "geom:area_square_m":1820362263.120488,
+    "geom:area_square_m":1820362883.172693,
     "geom:bbox":"-76.891479,20.940134,-76.30662,21.390444",
     "geom:latitude":21.152933,
     "geom:longitude":-76.640799,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.LT.JM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892361,
-    "wof:geomhash":"a93f1d66b13eecc234371028dbee4c7c",
+    "wof:geomhash":"0b9f5427aab70be23521c1f305525d4c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091905315,
-    "wof:lastmodified":1627507746,
+    "wof:lastmodified":1695886719,
     "wof:name":"Jesus Menendez",
     "wof:parent_id":85670439,
     "wof:placetype":"county",

--- a/data/109/190/535/5/1091905355.geojson
+++ b/data/109/190/535/5/1091905355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056438,
-    "geom:area_square_m":654052512.009084,
+    "geom:area_square_m":654052309.52974,
     "geom:bbox":"-76.546858,20.22704,-76.196177,20.557822",
     "geom:latitude":20.410804,
     "geom:longitude":-76.389149,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GR.JI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892363,
-    "wof:geomhash":"b845ead801454db265f887443bbae33d",
+    "wof:geomhash":"7c1a15bfbddb76ce365d555edd69b784",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091905355,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"Jiguani",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/541/7/1091905417.geojson
+++ b/data/109/190/541/7/1091905417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068405,
-    "geom:area_square_m":788418142.454687,
+    "geom:area_square_m":788418379.36413,
     "geom:bbox":"-78.039936,21.095473,-77.610435,21.367519",
     "geom:latitude":21.233677,
     "geom:longitude":-77.845456,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.JI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892365,
-    "wof:geomhash":"b91d07bd65212df81718b49bb92cce41",
+    "wof:geomhash":"86f14b4fb895c58d3dfc338ebd5e2499",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091905417,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"Jimaguayu",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/544/7/1091905447.geojson
+++ b/data/109/190/544/7/1091905447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077509,
-    "geom:area_square_m":895549615.497991,
+    "geom:area_square_m":895549615.498018,
     "geom:bbox":"-77.3522435912,20.642084122,-77.0144058742,21.0353862281",
     "geom:latitude":20.86767,
     "geom:longitude":-77.209433,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"CU.LT.JO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892366,
-    "wof:geomhash":"6333924b3fb1b2ff9768a5898ca87ecd",
+    "wof:geomhash":"ac30b3f0a95489d26b545414d7ec76cc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091905447,
-    "wof:lastmodified":1564327947,
+    "wof:lastmodified":1695886597,
     "wof:name":"Jobabo",
     "wof:parent_id":85670439,
     "wof:placetype":"county",

--- a/data/109/190/549/3/1091905493.geojson
+++ b/data/109/190/549/3/1091905493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044462,
-    "geom:area_square_m":506646885.794711,
+    "geom:area_square_m":506646885.794857,
     "geom:bbox":"-81.3798594665,22.6963399972,-81.0761222717,23.0048441201",
     "geom:latitude":22.845902,
     "geom:longitude":-81.239456,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.JO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892368,
-    "wof:geomhash":"d8fd992a42bd2286ec29c9681ecd8a04",
+    "wof:geomhash":"994fb982ddb97e320a500c6ef7092d93",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091905493,
-    "wof:lastmodified":1564327970,
+    "wof:lastmodified":1695886599,
     "wof:name":"Jovellanos",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/553/5/1091905535.geojson
+++ b/data/109/190/553/5/1091905535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000579,
-    "geom:area_square_m":6588807.321387,
+    "geom:area_square_m":6588803.178096,
     "geom:bbox":"-82.373002,23.110223,-82.343699,23.14625",
     "geom:latitude":23.12968,
     "geom:longitude":-82.359197,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CH.HV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892370,
-    "wof:geomhash":"51728f76e15d01158cd5b1e693587b65",
+    "wof:geomhash":"a38d7c4c59645f8065ba7763fbafa06e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091905535,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"La Habana Vieja",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/556/7/1091905567.geojson
+++ b/data/109/190/556/7/1091905567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003408,
-    "geom:area_square_m":38778590.574327,
+    "geom:area_square_m":38778590.574337,
     "geom:bbox":"-82.5096552143,22.9706936024,-82.4340144734,23.0748906662",
     "geom:latitude":23.029983,
     "geom:longitude":-82.472477,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CH.LL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892371,
-    "wof:geomhash":"34462b49fa723929205305ed355dc4be",
+    "wof:geomhash":"4a2f67fc00a13ff83056999a0a01480c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091905567,
-    "wof:lastmodified":1564327932,
+    "wof:lastmodified":1695886594,
     "wof:name":"La Lisa",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/560/9/1091905609.geojson
+++ b/data/109/190/560/9/1091905609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056491,
-    "geom:area_square_m":644177283.280745,
+    "geom:area_square_m":644177105.619091,
     "geom:bbox":"-83.660731,22.585528,-83.356487,22.914583",
     "geom:latitude":22.749184,
     "geom:longitude":-83.509928,
@@ -117,9 +117,10 @@
         "hasc:id":"CU.PD.LA",
         "wd:id":"Q2234325"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892373,
-    "wof:geomhash":"b7c8ca6e0aca318dd379abd0b619e2bb",
+    "wof:geomhash":"912d3063930d1e2c0173451bc058f67b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1091905609,
-    "wof:lastmodified":1690868508,
+    "wof:lastmodified":1695886158,
     "wof:name":"La Palma",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/561/5/1091905615.geojson
+++ b/data/109/190/561/5/1091905615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089332,
-    "geom:area_square_m":1026540834.11053,
+    "geom:area_square_m":1026540834.110567,
     "geom:bbox":"-79.5469212699,21.54205513,-78.9548802406,21.8705612218",
     "geom:latitude":21.670567,
     "geom:longitude":-79.243802,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"CU.SS.LS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892374,
-    "wof:geomhash":"bdddb3bf990d55614a3b84cbdcaad578",
+    "wof:geomhash":"5e9e49dc2dd05620e46f2b314b7221cd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091905615,
-    "wof:lastmodified":1564327935,
+    "wof:lastmodified":1695886595,
     "wof:name":"La Sierpe",
     "wof:parent_id":85670413,
     "wof:placetype":"county",

--- a/data/109/190/561/7/1091905617.geojson
+++ b/data/109/190/561/7/1091905617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038014,
-    "geom:area_square_m":434431266.215773,
+    "geom:area_square_m":434431810.17261,
     "geom:bbox":"-80.444225,22.322696,-80.217943,22.580857",
     "geom:latitude":22.449632,
     "geom:longitude":-80.325667,
@@ -123,9 +123,10 @@
         "hasc:id":"CU.CF.LA",
         "wd:id":"Q5045"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892376,
-    "wof:geomhash":"379109ab6fa911d6c6503ab42e8af49c",
+    "wof:geomhash":"f520df9a192afc57eb0eb4721ab84b54",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1091905617,
-    "wof:lastmodified":1690868509,
+    "wof:lastmodified":1695886592,
     "wof:name":"Lajas",
     "wof:parent_id":85670403,
     "wof:placetype":"county",

--- a/data/109/190/561/9/1091905619.geojson
+++ b/data/109/190/561/9/1091905619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076186,
-    "geom:area_square_m":879610977.606194,
+    "geom:area_square_m":879610434.602945,
     "geom:bbox":"-77.295133,20.723859,-76.832861,21.183655",
     "geom:latitude":20.977863,
     "geom:longitude":-77.031543,
@@ -237,9 +237,10 @@
         "hasc:id":"CU.LT.LT",
         "wd:id":"Q115527"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892378,
-    "wof:geomhash":"0ffb0467a11cdc1e11e7ecefa9ce4c3f",
+    "wof:geomhash":"f6b9d6b0935eed214ec3989e9793af26",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -249,7 +250,7 @@
         }
     ],
     "wof:id":1091905619,
-    "wof:lastmodified":1690868509,
+    "wof:lastmodified":1695886158,
     "wof:name":"Las Tunas",
     "wof:parent_id":85670439,
     "wof:placetype":"county",

--- a/data/109/190/566/3/1091905663.geojson
+++ b/data/109/190/566/3/1091905663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039586,
-    "geom:area_square_m":450771743.261369,
+    "geom:area_square_m":450771743.261398,
     "geom:bbox":"-81.7082895179,22.8284486636,-81.2947507059,23.0246880701",
     "geom:latitude":22.941849,
     "geom:longitude":-81.483302,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892379,
-    "wof:geomhash":"5ff4a9285d5a8ccf7b469b53c2285402",
+    "wof:geomhash":"eece8258919d1a82cbdf2a703eb75aa8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091905663,
-    "wof:lastmodified":1564327934,
+    "wof:lastmodified":1695886594,
     "wof:name":"Limonar",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/569/7/1091905697.geojson
+++ b/data/109/190/569/7/1091905697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065548,
-    "geom:area_square_m":748051480.947893,
+    "geom:area_square_m":748051480.947807,
     "geom:bbox":"-80.8471963793,22.4601396022,-80.5139803782,22.8300996392",
     "geom:latitude":22.640755,
     "geom:longitude":-80.653356,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892381,
-    "wof:geomhash":"cf59976cc9a43f0de42a8f5218da79cc",
+    "wof:geomhash":"b22908c192fe218378763e6e39d1ec9b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091905697,
-    "wof:lastmodified":1564327933,
+    "wof:lastmodified":1695886594,
     "wof:name":"Los Arabos",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/573/7/1091905737.geojson
+++ b/data/109/190/573/7/1091905737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069561,
-    "geom:area_square_m":794504190.055556,
+    "geom:area_square_m":794503966.64308,
     "geom:bbox":"-83.47426,22.322916,-83.079613,22.726157",
     "geom:latitude":22.527252,
     "geom:longitude":-83.254939,
@@ -96,9 +96,10 @@
         "hasc:id":"CU.PD.LS",
         "wd:id":"Q1870561"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892383,
-    "wof:geomhash":"52b9609e1af4ea74956c89dd9be3df35",
+    "wof:geomhash":"0ff61dc6da0ad7814a0a41165dc09176",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1091905737,
-    "wof:lastmodified":1690868516,
+    "wof:lastmodified":1695887185,
     "wof:name":"Los Palacios",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/577/9/1091905779.geojson
+++ b/data/109/190/577/9/1091905779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039255,
-    "geom:area_square_m":446971541.980719,
+    "geom:area_square_m":446971541.980723,
     "geom:bbox":"-81.9808229237,22.8411358364,-81.6813203923,23.0540143753",
     "geom:latitude":22.949594,
     "geom:longitude":-81.812723,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MQ.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892384,
-    "wof:geomhash":"54eaf48c16a420e21127789ba6dca602",
+    "wof:geomhash":"98d82df28d27fb996effc8819a44282e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091905779,
-    "wof:lastmodified":1564327975,
+    "wof:lastmodified":1695886599,
     "wof:name":"Madruga",
     "wof:parent_id":85670461,
     "wof:placetype":"county",

--- a/data/109/190/581/9/1091905819.geojson
+++ b/data/109/190/581/9/1091905819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044835,
-    "geom:area_square_m":520361784.570173,
+    "geom:area_square_m":520362008.061352,
     "geom:bbox":"-74.447207,20.063723,-74.133781,20.316223",
     "geom:latitude":20.178569,
     "geom:longitude":-74.282547,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GU.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892386,
-    "wof:geomhash":"137f1ba9593814849fdd638a1d78329b",
+    "wof:geomhash":"d5aad4e135c46938230a495fff6236d7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091905819,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"Maisi",
     "wof:parent_id":85670425,
     "wof:placetype":"county",

--- a/data/109/190/585/9/1091905859.geojson
+++ b/data/109/190/585/9/1091905859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046862,
-    "geom:area_square_m":537814544.967613,
+    "geom:area_square_m":537814544.967622,
     "geom:bbox":"-79.1284154813,21.6688715431,-78.7862785411,22.0237068998",
     "geom:latitude":21.852944,
     "geom:longitude":-78.986333,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CA.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892387,
-    "wof:geomhash":"300895c85d02e411a1b9b380ccc844e9",
+    "wof:geomhash":"adedaae6da8f5f8f4e1a76c1c1da956d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091905859,
-    "wof:lastmodified":1564327973,
+    "wof:lastmodified":1695886599,
     "wof:name":"Majagua",
     "wof:parent_id":85670419,
     "wof:placetype":"county",

--- a/data/109/190/590/1/1091905901.geojson
+++ b/data/109/190/590/1/1091905901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053141,
-    "geom:area_square_m":614102559.887179,
+    "geom:area_square_m":614102559.887212,
     "geom:bbox":"-76.9684334025,20.6837911759,-76.678013137,20.9746691809",
     "geom:latitude":20.84289,
     "geom:longitude":-76.815076,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"CU.LT.MJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892389,
-    "wof:geomhash":"a6db59c8847577afed6139b0118726a9",
+    "wof:geomhash":"3912b1e36734d7ca1d6cad769dc12e01",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1091905901,
-    "wof:lastmodified":1564327949,
+    "wof:lastmodified":1695886597,
     "wof:name":"Majibacoa",
     "wof:parent_id":85670439,
     "wof:placetype":"county",

--- a/data/109/190/594/5/1091905945.geojson
+++ b/data/109/190/594/5/1091905945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083779,
-    "geom:area_square_m":965402168.335027,
+    "geom:area_square_m":965402332.063274,
     "geom:bbox":"-77.145325,21.066262,-76.811056,21.457651",
     "geom:latitude":21.266408,
     "geom:longitude":-76.979771,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.LT.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892390,
-    "wof:geomhash":"86d777a54e3e01c6d501ffcd22425677",
+    "wof:geomhash":"2c5c9670e20607e6ab2ee514a70dc7be",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091905945,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"Manati",
     "wof:parent_id":85670439,
     "wof:placetype":"county",

--- a/data/109/190/597/9/1091905979.geojson
+++ b/data/109/190/597/9/1091905979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093403,
-    "geom:area_square_m":1069753757.619997,
+    "geom:area_square_m":1069753757.619955,
     "geom:bbox":"-80.1052319481,21.9533787521,-79.7468439898,22.3604312396",
     "geom:latitude":22.144641,
     "geom:longitude":-79.930502,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"CU.VC.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892392,
-    "wof:geomhash":"841e66625ee1ab211b2408f5496b3303",
+    "wof:geomhash":"adad2b8ad19da78c6e909689c1f843b7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091905979,
-    "wof:lastmodified":1564327949,
+    "wof:lastmodified":1695886597,
     "wof:name":"Manicaragua",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/602/7/1091906027.geojson
+++ b/data/109/190/602/7/1091906027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08075,
-    "geom:area_square_m":923523519.180502,
+    "geom:area_square_m":923523730.94627,
     "geom:bbox":"-84.447136,22.131768,-84.086532,22.607225",
     "geom:latitude":22.343433,
     "geom:longitude":-84.261213,
@@ -105,9 +105,10 @@
         "hasc:id":"CU.PD.MA",
         "wd:id":"Q2213002"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892393,
-    "wof:geomhash":"af337ec6a6f0f66ae1f4cb05fd991090",
+    "wof:geomhash":"5be2477860f7d158b2f3e76b2b38b183",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091906027,
-    "wof:lastmodified":1690868512,
+    "wof:lastmodified":1695887185,
     "wof:name":"Mantua",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/606/1/1091906061.geojson
+++ b/data/109/190/606/1/1091906061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046207,
-    "geom:area_square_m":536399187.646149,
+    "geom:area_square_m":536399187.646102,
     "geom:bbox":"-75.1262099404,20.0103870705,-74.849785445,20.3065769718",
     "geom:latitude":20.145693,
     "geom:longitude":-74.971554,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GU.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892395,
-    "wof:geomhash":"40f69e24ecaf71eab358494851212ef4",
+    "wof:geomhash":"02bbeb0548fd0db0001e7a6dea8d0578",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091906061,
-    "wof:lastmodified":1564327967,
+    "wof:lastmodified":1695886598,
     "wof:name":"Manuel Tames",
     "wof:parent_id":85670425,
     "wof:placetype":"county",

--- a/data/109/190/608/9/1091906089.geojson
+++ b/data/109/190/608/9/1091906089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043788,
-    "geom:area_square_m":507985979.059443,
+    "geom:area_square_m":507985979.059361,
     "geom:bbox":"-77.2474234573,20.0566944849,-76.972943309,20.4179354794",
     "geom:latitude":20.24757,
     "geom:longitude":-77.094647,
@@ -110,9 +110,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GR.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892396,
-    "wof:geomhash":"1d260a7446e3730bb5f8ca4bae7e299f",
+    "wof:geomhash":"028391a1309d518ad71a653b55c28ff7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1091906089,
-    "wof:lastmodified":1564327967,
+    "wof:lastmodified":1695886598,
     "wof:name":"Manzanillo",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/613/7/1091906137.geojson
+++ b/data/109/190/613/7/1091906137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00208,
-    "geom:area_square_m":23667903.321098,
+    "geom:area_square_m":23667903.321088,
     "geom:bbox":"-82.4480515839,23.0273828221,-82.3953099988,23.1032469932",
     "geom:latitude":23.066511,
     "geom:longitude":-82.423004,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CH.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892398,
-    "wof:geomhash":"5928bd37a39849e887be3f7ff298e516",
+    "wof:geomhash":"a14ab717929db6d18def5a5a69ef6fe3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091906137,
-    "wof:lastmodified":1564327951,
+    "wof:lastmodified":1695886597,
     "wof:name":"Marianao",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/617/9/1091906179.geojson
+++ b/data/109/190/617/9/1091906179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024464,
-    "geom:area_square_m":278504356.220902,
+    "geom:area_square_m":278503960.388923,
     "geom:bbox":"-82.978864,22.908599,-82.666296,23.030126",
     "geom:latitude":22.97611,
     "geom:longitude":-82.817018,
@@ -129,9 +129,10 @@
         "hasc:id":"CU.AR.MR",
         "wd:id":"Q116156"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892399,
-    "wof:geomhash":"24893cf107c92465f213b833132b4133",
+    "wof:geomhash":"ef902f29ac632d4613778eb66159d47d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1091906179,
-    "wof:lastmodified":1690868511,
+    "wof:lastmodified":1695886593,
     "wof:name":"Mariel",
     "wof:parent_id":85670449,
     "wof:placetype":"county",

--- a/data/109/190/622/5/1091906225.geojson
+++ b/data/109/190/622/5/1091906225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092887,
-    "geom:area_square_m":1057187648.109149,
+    "geom:area_square_m":1057188371.021618,
     "geom:bbox":"-81.093856,22.802565,-80.469612,23.277082",
     "geom:latitude":23.009037,
     "geom:longitude":-80.83987,
@@ -118,9 +118,10 @@
         "hasc:id":"CU.MA.MR",
         "wd:id":"Q5054"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892401,
-    "wof:geomhash":"ce8221d7e0225ad9d1842beaed1b37f2",
+    "wof:geomhash":"acd57f0be412fc660b1c4934e416d871",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1091906225,
-    "wof:lastmodified":1690868518,
+    "wof:lastmodified":1695887185,
     "wof:name":"Marti",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/627/3/1091906273.geojson
+++ b/data/109/190/627/3/1091906273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029492,
-    "geom:area_square_m":335545750.666097,
+    "geom:area_square_m":335545750.666151,
     "geom:bbox":"-81.7514901536,22.9596698661,-81.4518441956,23.153749466",
     "geom:latitude":23.057095,
     "geom:longitude":-81.605163,
@@ -182,9 +182,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892402,
-    "wof:geomhash":"81847cddfd891b4886e0a5f72e96186b",
+    "wof:geomhash":"40ea118adf58f056700a5fe0f21cda90",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":1091906273,
-    "wof:lastmodified":1564327941,
+    "wof:lastmodified":1695886596,
     "wof:name":"Matanzas",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/630/5/1091906305.geojson
+++ b/data/109/190/630/5/1091906305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11695,
-    "geom:area_square_m":1353562064.346873,
+    "geom:area_square_m":1353562064.346981,
     "geom:bbox":"-75.9407935966,20.4024974606,-75.4440422166,20.7984272703",
     "geom:latitude":20.609645,
     "geom:longitude":-75.698754,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892404,
-    "wof:geomhash":"3279b49d11cd6c493d71446904da3501",
+    "wof:geomhash":"2d3b00ee0adc5c957d5c507c8b276917",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1091906305,
-    "wof:lastmodified":1564327967,
+    "wof:lastmodified":1695886598,
     "wof:name":"Mayari",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/634/1/1091906341.geojson
+++ b/data/109/190/634/1/1091906341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033769,
-    "geom:area_square_m":392219942.569613,
+    "geom:area_square_m":392219961.832588,
     "geom:bbox":"-77.501838,19.953464,-77.206508,20.187609",
     "geom:latitude":20.064693,
     "geom:longitude":-77.371461,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GR.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892405,
-    "wof:geomhash":"74574ef30f10734c6186722cc026ad39",
+    "wof:geomhash":"f34836ec979a5e358f1fc8f6b2eb6358",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1091906341,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"Media Luna",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/637/1/1091906371.geojson
+++ b/data/109/190/637/1/1091906371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030333,
-    "geom:area_square_m":351474340.242885,
+    "geom:area_square_m":351474340.242949,
     "geom:bbox":"-76.1008701041,20.3047895323,-75.8226088744,20.5716834096",
     "geom:latitude":20.434622,
     "geom:longitude":-75.961038,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"CU.SC.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892407,
-    "wof:geomhash":"5504f89375d81516d3eb7b81cd634e22",
+    "wof:geomhash":"086672218b5f5e460850f5bc5f98557b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091906371,
-    "wof:lastmodified":1564327967,
+    "wof:lastmodified":1695886598,
     "wof:name":"Mella",
     "wof:parent_id":85670441,
     "wof:placetype":"county",

--- a/data/109/190/641/7/1091906417.geojson
+++ b/data/109/190/641/7/1091906417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076697,
-    "geom:area_square_m":875900152.428537,
+    "geom:area_square_m":875900152.428563,
     "geom:bbox":"-84.1390995047,22.3413451313,-83.8104894086,22.750389099",
     "geom:latitude":22.544412,
     "geom:longitude":-83.963531,
@@ -94,9 +94,10 @@
         "hasc:id":"CU.PD.MM",
         "wd:id":"Q2204246"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892408,
-    "wof:geomhash":"1f65aa3838d54c7558237d16dfb42df4",
+    "wof:geomhash":"d08d0ac2476df5a1cceec4efa64a05b5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1091906417,
-    "wof:lastmodified":1561766476,
+    "wof:lastmodified":1695887185,
     "wof:name":"Minas De Matahambre",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/645/7/1091906457.geojson
+++ b/data/109/190/645/7/1091906457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09039,
-    "geom:area_square_m":1039355236.859343,
+    "geom:area_square_m":1039355236.859371,
     "geom:bbox":"-77.7695943405,21.4066764792,-77.3673957528,21.777111053",
     "geom:latitude":21.579245,
     "geom:longitude":-77.546173,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892410,
-    "wof:geomhash":"be5d79a1e2053a9af6d33f3d4220e9cd",
+    "wof:geomhash":"995709e36782a34064437a9e9f8d0ad4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091906457,
-    "wof:lastmodified":1564327940,
+    "wof:lastmodified":1695886595,
     "wof:name":"Minas",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/648/3/1091906483.geojson
+++ b/data/109/190/648/3/1091906483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063118,
-    "geom:area_square_m":730823968.3034,
+    "geom:area_square_m":730823968.303482,
     "geom:bbox":"-75.0575432573,20.3955885415,-74.718733426,20.695417404",
     "geom:latitude":20.546068,
     "geom:longitude":-74.909339,
@@ -218,9 +218,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892411,
-    "wof:geomhash":"58e59a318c9867436026553bf163240e",
+    "wof:geomhash":"acbc0f9d6c30c209838e9687c64f5bf0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -230,7 +231,7 @@
         }
     ],
     "wof:id":1091906483,
-    "wof:lastmodified":1564327961,
+    "wof:lastmodified":1695886597,
     "wof:name":"Moa",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/652/5/1091906525.geojson
+++ b/data/109/190/652/5/1091906525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05314,
-    "geom:area_square_m":608419052.458712,
+    "geom:area_square_m":608419052.458927,
     "geom:bbox":"-78.7409045083,21.9952677019,-78.3679276879,22.387083054",
     "geom:latitude":22.191032,
     "geom:longitude":-78.590255,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CA.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892413,
-    "wof:geomhash":"1ca6618a27a90c5cfde0c8af3aafe7fa",
+    "wof:geomhash":"ebf3d553171aa6b8f0368367bcc67819",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1091906525,
-    "wof:lastmodified":1564327965,
+    "wof:lastmodified":1695886598,
     "wof:name":"Moron",
     "wof:parent_id":85670419,
     "wof:placetype":"county",

--- a/data/109/190/656/3/1091906563.geojson
+++ b/data/109/190/656/3/1091906563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.207704,
-    "geom:area_square_m":2386695957.372408,
+    "geom:area_square_m":2386695957.371999,
     "geom:bbox":"-83.207947,21.439556,-81.359581,21.947056",
     "geom:latitude":21.674996,
     "geom:longitude":-82.788054,
@@ -232,12 +232,13 @@
         "hasc:id":"CU.IJ.IJ",
         "wd:id":"Q115027"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85670405
     ],
     "wof:country":"CU",
     "wof:created":1473892414,
-    "wof:geomhash":"cec96f12402e17d458e7df3112d5d37b",
+    "wof:geomhash":"7d7002081fe50dbb38749e065f2b582f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -247,7 +248,7 @@
         }
     ],
     "wof:id":1091906563,
-    "wof:lastmodified":1690868513,
+    "wof:lastmodified":1695886411,
     "wof:name":"Municipio Especial Isla De La Juventud",
     "wof:parent_id":85670405,
     "wof:placetype":"county",

--- a/data/109/190/659/9/1091906599.geojson
+++ b/data/109/190/659/9/1091906599.geojson
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892416,
-    "wof:geomhash":"d27c9457289776f5ef25f35587ade16b",
+    "wof:geomhash":"d42538480ac7124561dd18a6655964dc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091906599,
-    "wof:lastmodified":1564327944,
+    "wof:lastmodified":1695886596,
     "wof:name":"Najasa",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/663/7/1091906637.geojson
+++ b/data/109/190/663/7/1091906637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055484,
-    "geom:area_square_m":644490353.147247,
+    "geom:area_square_m":644491094.231915,
     "geom:bbox":"-75.494284,19.878805,-75.221269,20.205909",
     "geom:latitude":20.050067,
     "geom:longitude":-75.353149,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GU.NP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892418,
-    "wof:geomhash":"c838cb6514d06734c820d2455fc38da7",
+    "wof:geomhash":"229afb87c62d3f4286bef519df13efe9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091906637,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"Niceto Perez",
     "wof:parent_id":85670425,
     "wof:placetype":"county",

--- a/data/109/190/667/7/1091906677.geojson
+++ b/data/109/190/667/7/1091906677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053075,
-    "geom:area_square_m":616907944.408518,
+    "geom:area_square_m":616907767.190357,
     "geom:bbox":"-77.74128,19.82625,-77.412605,20.108429",
     "geom:latitude":19.946632,
     "geom:longitude":-77.564907,
@@ -102,9 +102,10 @@
         "hasc:id":"CU.GR.NI",
         "wd:id":"Q972546"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892419,
-    "wof:geomhash":"25c5de49e73c9171e93d96ae0144c6c6",
+    "wof:geomhash":"be026534df9f082c62178851e758c593",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091906677,
-    "wof:lastmodified":1690868513,
+    "wof:lastmodified":1695887185,
     "wof:name":"Niquero",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/671/9/1091906719.geojson
+++ b/data/109/190/671/9/1091906719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045226,
-    "geom:area_square_m":515844070.542523,
+    "geom:area_square_m":515844070.542575,
     "geom:bbox":"-81.868695456,22.572055817,-81.5816025426,22.858968976",
     "geom:latitude":22.716535,
     "geom:longitude":-81.721464,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MQ.NP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892421,
-    "wof:geomhash":"1087b4f717df2d281b2d9f2a5b492681",
+    "wof:geomhash":"502800b005f186f1a68585dbcbe184fe",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091906719,
-    "wof:lastmodified":1564327952,
+    "wof:lastmodified":1695886597,
     "wof:name":"Nueva Paz",
     "wof:parent_id":85670461,
     "wof:placetype":"county",

--- a/data/109/190/676/5/1091906765.geojson
+++ b/data/109/190/676/5/1091906765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12932,
-    "geom:area_square_m":1483888492.306452,
+    "geom:area_square_m":1483888810.690871,
     "geom:bbox":"-78.332916,21.399991,-76.951279,22.482916",
     "geom:latitude":21.876172,
     "geom:longitude":-77.563424,
@@ -128,9 +128,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.NU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892423,
-    "wof:geomhash":"e82d28777830eaeb1282092554db85b5",
+    "wof:geomhash":"3d54e822d1b262b7ae2deddd604a8ff4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1091906765,
-    "wof:lastmodified":1636504852,
+    "wof:lastmodified":1695886159,
     "wof:name":"Nuevitas",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/682/3/1091906823.geojson
+++ b/data/109/190/682/3/1091906823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072854,
-    "geom:area_square_m":845388616.642884,
+    "geom:area_square_m":845388570.094324,
     "geom:bbox":"-76.222006,20.023847,-75.892336,20.450147",
     "geom:latitude":20.209565,
     "geom:longitude":-76.057824,
@@ -122,9 +122,10 @@
     "wof:concordances":{
         "hasc:id":"CU.SC.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892425,
-    "wof:geomhash":"3acdacde2ddbedf028dc99272b2148fa",
+    "wof:geomhash":"55623fd153cdf948feebcd989b19f450",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1091906823,
-    "wof:lastmodified":1636504852,
+    "wof:lastmodified":1695886159,
     "wof:name":"Palma Soriano",
     "wof:parent_id":85670441,
     "wof:placetype":"county",

--- a/data/109/190/685/1/1091906851.geojson
+++ b/data/109/190/685/1/1091906851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026739,
-    "geom:area_square_m":305932358.524779,
+    "geom:area_square_m":305932372.700367,
     "geom:bbox":"-80.49875,22.192403,-80.246895,22.429902",
     "geom:latitude":22.289066,
     "geom:longitude":-80.382205,
@@ -120,9 +120,10 @@
         "hasc:id":"CU.CF.PA",
         "wd:id":"Q5008"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892426,
-    "wof:geomhash":"0145b4d36acd9e74cff3b5b433b98659",
+    "wof:geomhash":"7560d70dfb88a0d9d88af246f0ba054e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1091906851,
-    "wof:lastmodified":1690868519,
+    "wof:lastmodified":1695887185,
     "wof:name":"Palmira",
     "wof:parent_id":85670403,
     "wof:placetype":"county",

--- a/data/109/190/689/3/1091906893.geojson
+++ b/data/109/190/689/3/1091906893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034152,
-    "geom:area_square_m":389456455.520242,
+    "geom:area_square_m":389456455.520191,
     "geom:bbox":"-81.4958018399,22.6210556095,-81.2088038175,22.8588333213",
     "geom:latitude":22.745087,
     "geom:longitude":-81.357659,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.PB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892428,
-    "wof:geomhash":"4ca1bf9009ed6bdd1d38d1c7e1d966c3",
+    "wof:geomhash":"ae1fa92f61c2e0d2e16274cff41ca2f4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1091906893,
-    "wof:lastmodified":1564327940,
+    "wof:lastmodified":1695886596,
     "wof:name":"Pedro Betancourt",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/693/3/1091906933.geojson
+++ b/data/109/190/693/3/1091906933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024647,
-    "geom:area_square_m":280862259.348122,
+    "geom:area_square_m":280862259.348026,
     "geom:bbox":"-81.1208541258,22.6994667109,-80.9454364226,22.9643746925",
     "geom:latitude":22.840579,
     "geom:longitude":-81.028645,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.PE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892429,
-    "wof:geomhash":"a0eba4eb5868fa368f250f78a954767d",
+    "wof:geomhash":"b884db41eaca2daa30a4e405fa5fa846",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091906933,
-    "wof:lastmodified":1564327944,
+    "wof:lastmodified":1695886596,
     "wof:name":"Perico",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/696/5/1091906965.geojson
+++ b/data/109/190/696/5/1091906965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037953,
-    "geom:area_square_m":441171964.672333,
+    "geom:area_square_m":441171964.672319,
     "geom:bbox":"-77.4540156605,19.847888947,-77.0273860059,20.0264439022",
     "geom:latitude":19.934562,
     "geom:longitude":-77.254142,
@@ -85,9 +85,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GR.PI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892431,
-    "wof:geomhash":"0d63943d2f19fa0a380f9426bf1c2b44",
+    "wof:geomhash":"bbf8281916dd249cefac6236b34643b1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1091906965,
-    "wof:lastmodified":1564327969,
+    "wof:lastmodified":1695886599,
     "wof:name":"Pilon",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/700/7/1091907007.geojson
+++ b/data/109/190/700/7/1091907007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064366,
-    "geom:area_square_m":736078238.622515,
+    "geom:area_square_m":736078276.192464,
     "geom:bbox":"-83.82632,21.937056,-83.346252,22.53587",
     "geom:latitude":22.35499,
     "geom:longitude":-83.621672,
@@ -259,9 +259,10 @@
         "hasc:id":"CU.PD.PR",
         "wd:id":"Q244139"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892433,
-    "wof:geomhash":"4a18d900a7c70ceb305c6a36cef05c7e",
+    "wof:geomhash":"8ea1ed7218c295705172753b8fa93165",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -271,7 +272,7 @@
         }
     ],
     "wof:id":1091907007,
-    "wof:lastmodified":1690868510,
+    "wof:lastmodified":1695886593,
     "wof:name":"Pinar Del Rio",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/705/3/1091907053.geojson
+++ b/data/109/190/705/3/1091907053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052708,
-    "geom:area_square_m":603114894.185263,
+    "geom:area_square_m":603115349.673266,
     "geom:bbox":"-79.848355,22.142761,-79.473392,22.400064",
     "geom:latitude":22.273721,
     "geom:longitude":-79.659155,
@@ -150,9 +150,10 @@
         "hasc:id":"CU.VC.RE",
         "wd:id":"Q280795"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892435,
-    "wof:geomhash":"b390af7bacc25b55313d5292a433821c",
+    "wof:geomhash":"4d293febaa70fef307333c96f22a43da",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1091907053,
-    "wof:lastmodified":1690868516,
+    "wof:lastmodified":1695886159,
     "wof:name":"Placetas",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/708/3/1091907083.geojson
+++ b/data/109/190/708/3/1091907083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003439,
-    "geom:area_square_m":39112403.726329,
+    "geom:area_square_m":39112403.726355,
     "geom:bbox":"-82.5389776885,23.0507225905,-82.404465873,23.1332178039",
     "geom:latitude":23.088688,
     "geom:longitude":-82.461807,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CH.PL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892436,
-    "wof:geomhash":"485b09a291ae611e59918e3908199788",
+    "wof:geomhash":"f4649db1f0ee75bf9f7cb173e8ea75e8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091907083,
-    "wof:lastmodified":1564327934,
+    "wof:lastmodified":1695886594,
     "wof:name":"Playa",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/712/5/1091907125.geojson
+++ b/data/109/190/712/5/1091907125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001306,
-    "geom:area_square_m":14847814.990356,
+    "geom:area_square_m":14847754.426773,
     "geom:bbox":"-82.417216,23.100875,-82.366253,23.147888",
     "geom:latitude":23.127988,
     "geom:longitude":-82.392197,
@@ -101,9 +101,10 @@
         "hasc:id":"CU.CH.PR",
         "wd:id":"Q2099152"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892438,
-    "wof:geomhash":"c38feff6cee3389c21331f98c58ba245",
+    "wof:geomhash":"ffba4d847a09cebf96c0e28b3dcd71a2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091907125,
-    "wof:lastmodified":1690868515,
+    "wof:lastmodified":1695886594,
     "wof:name":"Plaza De La Revolucion",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/716/7/1091907167.geojson
+++ b/data/109/190/716/7/1091907167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062058,
-    "geom:area_square_m":712040976.441136,
+    "geom:area_square_m":712041248.579281,
     "geom:bbox":"-78.574998,21.753316,-78.145976,22.037982",
     "geom:latitude":21.888384,
     "geom:longitude":-78.374231,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CA.PE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892439,
-    "wof:geomhash":"45aa862508ecf5efb8556629913f7254",
+    "wof:geomhash":"2b423594dc87695c827173599841c8b4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091907167,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"Primero De Enero",
     "wof:parent_id":85670419,
     "wof:placetype":"county",

--- a/data/109/190/720/9/1091907209.geojson
+++ b/data/109/190/720/9/1091907209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027799,
-    "geom:area_square_m":316873538.199592,
+    "geom:area_square_m":316873479.024043,
     "geom:bbox":"-80.404429,22.703726,-80.173279,22.930525",
     "geom:latitude":22.804404,
     "geom:longitude":-80.285219,
@@ -110,9 +110,10 @@
         "hasc:id":"CU.VC.QG",
         "wd:id":"Q5006"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892440,
-    "wof:geomhash":"18ad825dc1bbe61bc0e2de5ecb16d53c",
+    "wof:geomhash":"b96a825898cf44f13baabe443607409a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1091907209,
-    "wof:lastmodified":1690868523,
+    "wof:lastmodified":1695886594,
     "wof:name":"Quemado De Guines",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/722/3/1091907223.geojson
+++ b/data/109/190/722/3/1091907223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02445,
-    "geom:area_square_m":278708296.53913,
+    "geom:area_square_m":278708389.846777,
     "geom:bbox":"-82.470594,22.679575,-82.282549,22.911035",
     "geom:latitude":22.799698,
     "geom:longitude":-82.388796,
@@ -118,9 +118,10 @@
         "hasc:id":"CU.MQ.QU",
         "wd:id":"Q2123580"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892442,
-    "wof:geomhash":"f3a9d6b6baab9182705e88de1de9cb5a",
+    "wof:geomhash":"b02bea23c14b80f9d2d42adaae5c3686",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1091907223,
-    "wof:lastmodified":1690868515,
+    "wof:lastmodified":1695887185,
     "wof:name":"Quivican",
     "wof:parent_id":85670461,
     "wof:placetype":"county",

--- a/data/109/190/726/7/1091907267.geojson
+++ b/data/109/190/726/7/1091907267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053595,
-    "geom:area_square_m":618645592.303923,
+    "geom:area_square_m":618645592.303894,
     "geom:bbox":"-76.1925867083,20.8797334347,-75.8191140739,21.124584198",
     "geom:latitude":21.01221,
     "geom:longitude":-76.001993,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.RF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892443,
-    "wof:geomhash":"5eae735a552f64eb02c4aaa1595abb92",
+    "wof:geomhash":"b8efae6dd6fb99d6cb79fb2264918cb8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091907267,
-    "wof:lastmodified":1564327974,
+    "wof:lastmodified":1695886599,
     "wof:name":"Rafael Freyre",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/731/1/1091907311.geojson
+++ b/data/109/190/731/1/1091907311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048404,
-    "geom:area_square_m":553309152.925195,
+    "geom:area_square_m":553309359.148721,
     "geom:bbox":"-80.251653,22.237969,-79.992578,22.59093",
     "geom:latitude":22.413072,
     "geom:longitude":-80.120712,
@@ -120,9 +120,10 @@
         "hasc:id":"CU.VC.RA",
         "wd:id":"Q5003"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892445,
-    "wof:geomhash":"d4f984302a28dc8a2e14b014c1b19a16",
+    "wof:geomhash":"157a6aa2ca6bcd238dfbba6c6ca1745f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1091907311,
-    "wof:lastmodified":1690868510,
+    "wof:lastmodified":1695886592,
     "wof:name":"Ranchuelo",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/733/5/1091907335.geojson
+++ b/data/109/190/733/5/1091907335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001285,
-    "geom:area_square_m":14609825.231775,
+    "geom:area_square_m":14609774.695577,
     "geom:bbox":"-82.353634,23.104716,-82.308759,23.155153",
     "geom:latitude":23.129596,
     "geom:longitude":-82.332507,
@@ -114,9 +114,10 @@
         "hasc:id":"CU.CH.RE",
         "wd:id":"Q2066278"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892446,
-    "wof:geomhash":"a666bbdc84bb36d337ab720fee4cae15",
+    "wof:geomhash":"860cbfeda8fd12a21774b06e39c00e38",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1091907335,
-    "wof:lastmodified":1690868516,
+    "wof:lastmodified":1695887185,
     "wof:name":"Regla",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/737/1/1091907371.geojson
+++ b/data/109/190/737/1/1091907371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048168,
-    "geom:area_square_m":550795481.982162,
+    "geom:area_square_m":550795330.620867,
     "geom:bbox":"-79.66012,22.221104,-79.313916,22.535657",
     "geom:latitude":22.36679,
     "geom:longitude":-79.49606,
@@ -114,9 +114,10 @@
         "hasc:id":"CU.VC.CB",
         "wd:id":"Q280795"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892448,
-    "wof:geomhash":"082edf4d60cb7f091ab9e27a75600209",
+    "wof:geomhash":"21d77f6a574c780c04c4a67f6422ebce",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1091907371,
-    "wof:lastmodified":1690868509,
+    "wof:lastmodified":1695886592,
     "wof:name":"Remedios",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/741/3/1091907413.geojson
+++ b/data/109/190/741/3/1091907413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13193,
-    "geom:area_square_m":1527032873.276222,
+    "geom:area_square_m":1527033247.343856,
     "geom:bbox":"-77.249611,20.366944,-76.72935,20.774852",
     "geom:latitude":20.599653,
     "geom:longitude":-76.976955,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GR.RC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892449,
-    "wof:geomhash":"2eb74c64166f6fb07a89e345fbab06d8",
+    "wof:geomhash":"10a7ad2282041c9ad8f03d8ca0cce375",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091907413,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"Rio Cauto",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/745/5/1091907455.geojson
+++ b/data/109/190/745/5/1091907455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048814,
-    "geom:area_square_m":558050438.869254,
+    "geom:area_square_m":558050033.433732,
     "geom:bbox":"-80.656699,22.214582,-80.408024,22.586273",
     "geom:latitude":22.399898,
     "geom:longitude":-80.522286,
@@ -117,9 +117,10 @@
         "hasc:id":"CU.CF.RO",
         "wd:id":"Q5004"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892451,
-    "wof:geomhash":"d2de999b3db21fbf7f06da29a2d2e96d",
+    "wof:geomhash":"4ec713c94a2bd156a1078ce91c8990ad",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1091907455,
-    "wof:lastmodified":1690868522,
+    "wof:lastmodified":1695887186,
     "wof:name":"Rodas",
     "wof:parent_id":85670403,
     "wof:placetype":"county",

--- a/data/109/190/750/3/1091907503.geojson
+++ b/data/109/190/750/3/1091907503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061398,
-    "geom:area_square_m":710995597.614303,
+    "geom:area_square_m":710995551.706924,
     "geom:bbox":"-75.426396,20.378524,-75.027718,20.670086",
     "geom:latitude":20.527255,
     "geom:longitude":-75.232234,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892453,
-    "wof:geomhash":"9dcba2e36bca74fe820b536f050395b2",
+    "wof:geomhash":"cc51d0e877e1c6230ca44cb5ebbe7fe4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091907503,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"Sagua De Tanamo",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/754/5/1091907545.geojson
+++ b/data/109/190/754/5/1091907545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085225,
-    "geom:area_square_m":970978818.110353,
+    "geom:area_square_m":970978818.110331,
     "geom:bbox":"-80.464614868,22.6707016369,-79.653778076,23.15625",
     "geom:latitude":22.870946,
     "geom:longitude":-80.089326,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"CU.VC.SG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892454,
-    "wof:geomhash":"075227d5e83d3ff970477be4d9f008e1",
+    "wof:geomhash":"f760e35b9438310a1802f4bb2efbf5c4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091907545,
-    "wof:lastmodified":1564327934,
+    "wof:lastmodified":1695886594,
     "wof:name":"Sagua La Grande",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/758/7/1091907587.geojson
+++ b/data/109/190/758/7/1091907587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01157,
-    "geom:area_square_m":131801049.315127,
+    "geom:area_square_m":131801443.98799,
     "geom:bbox":"-82.576494,22.813952,-82.426146,22.938919",
     "geom:latitude":22.883329,
     "geom:longitude":-82.505232,
@@ -122,9 +122,10 @@
         "hasc:id":"CU.AR.SA",
         "wd:id":"Q114984"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892456,
-    "wof:geomhash":"196248c7ee012de02d5e8d258a1987c5",
+    "wof:geomhash":"1d939333592381159721785367b2c93c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1091907587,
-    "wof:lastmodified":1690868517,
+    "wof:lastmodified":1695887185,
     "wof:name":"San Antonio De Los Banos",
     "wof:parent_id":85670449,
     "wof:placetype":"county",

--- a/data/109/190/763/3/1091907633.geojson
+++ b/data/109/190/763/3/1091907633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050828,
-    "geom:area_square_m":590040370.382771,
+    "geom:area_square_m":590040818.958417,
     "geom:bbox":"-75.038639,19.967795,-74.677788,20.344827",
     "geom:latitude":20.146916,
     "geom:longitude":-74.809847,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GU.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892457,
-    "wof:geomhash":"533ff2d5da71643d6fbcc1545ff3c1b6",
+    "wof:geomhash":"49ce072b27cfa2f6209c0579ec26dbe4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091907633,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"San Antonio Del Sur",
     "wof:parent_id":85670425,
     "wof:placetype":"county",

--- a/data/109/190/767/9/1091907679.geojson
+++ b/data/109/190/767/9/1091907679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08224,
-    "geom:area_square_m":938405093.774621,
+    "geom:area_square_m":938404364.937263,
     "geom:bbox":"-83.361963,22.486408,-82.884012,22.815183",
     "geom:latitude":22.660864,
     "geom:longitude":-83.10946,
@@ -145,9 +145,10 @@
         "hasc:id":"CU.AR.SC",
         "wd:id":"Q559801"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892459,
-    "wof:geomhash":"951ae87bcba130db34e61a22d77c9fdb",
+    "wof:geomhash":"2de3d77a89620b653eed5b4b0e48bdd5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1091907679,
-    "wof:lastmodified":1690868516,
+    "wof:lastmodified":1695886159,
     "wof:name":"San Cristobal",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/772/5/1091907725.geojson
+++ b/data/109/190/772/5/1091907725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051998,
-    "geom:area_square_m":592129476.591407,
+    "geom:area_square_m":592129883.699773,
     "geom:bbox":"-82.308622,22.805707,-81.964652,23.079975",
     "geom:latitude":22.937949,
     "geom:longitude":-82.151328,
@@ -188,9 +188,10 @@
         "hasc:id":"CU.MQ.SJ",
         "wd:id":"Q1001941"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892460,
-    "wof:geomhash":"fbee845ddf24ffa242f379bd03a608d2",
+    "wof:geomhash":"ec1ab58f0758908800fa0473d5245d89",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":1091907725,
-    "wof:lastmodified":1690868521,
+    "wof:lastmodified":1695887186,
     "wof:name":"San Jose De Las Lajas",
     "wof:parent_id":85670461,
     "wof:placetype":"county",

--- a/data/109/190/775/5/1091907755.geojson
+++ b/data/109/190/775/5/1091907755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035458,
-    "geom:area_square_m":405676021.845006,
+    "geom:area_square_m":405675673.778989,
     "geom:bbox":"-83.969257,22.149676,-83.748398,22.443434",
     "geom:latitude":22.290504,
     "geom:longitude":-83.869513,
@@ -106,9 +106,10 @@
         "hasc:id":"CU.PD.SJ",
         "wd:id":"Q1716152"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892462,
-    "wof:geomhash":"7fe680885690ceaa3af3380ef534f210",
+    "wof:geomhash":"d71452279595b86a2a8ac2576d40410a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091907755,
-    "wof:lastmodified":1690868521,
+    "wof:lastmodified":1695887186,
     "wof:name":"San Juan Y Martinez",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/784/3/1091907843.geojson
+++ b/data/109/190/784/3/1091907843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002264,
-    "geom:area_square_m":25757821.179398,
+    "geom:area_square_m":25757889.337615,
     "geom:bbox":"-82.344387,23.05348,-82.267065,23.111373",
     "geom:latitude":23.081893,
     "geom:longitude":-82.306936,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CH.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892465,
-    "wof:geomhash":"65ea87160c54f83b3dab10071801c810",
+    "wof:geomhash":"8185331c3f6f577f0146d0c74f44a7f5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1091907843,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"San Miguel Del Padron",
     "wof:parent_id":85670445,
     "wof:placetype":"county",

--- a/data/109/190/787/7/1091907877.geojson
+++ b/data/109/190/787/7/1091907877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021272,
-    "geom:area_square_m":242557034.405669,
+    "geom:area_square_m":242556979.544286,
     "geom:bbox":"-81.984752,22.672056,-81.80834,22.85315",
     "geom:latitude":22.754987,
     "geom:longitude":-81.894319,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MQ.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892466,
-    "wof:geomhash":"4b9a3df780dc8380b75d76008c0a4a2c",
+    "wof:geomhash":"f92ae4ecae7bc1a38f187087704b3bdd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091907877,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"San Nicolas",
     "wof:parent_id":85670461,
     "wof:placetype":"county",

--- a/data/109/190/791/9/1091907919.geojson
+++ b/data/109/190/791/9/1091907919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101792,
-    "geom:area_square_m":1168399330.766134,
+    "geom:area_square_m":1168399309.413691,
     "geom:bbox":"-79.718405,21.616194,-79.253956,22.025866",
     "geom:latitude":21.832483,
     "geom:longitude":-79.493363,
@@ -240,9 +240,10 @@
         "hasc:id":"CU.SS.SS",
         "wd:id":"Q845720"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892467,
-    "wof:geomhash":"a818e19046a565c3115885639c26300e",
+    "wof:geomhash":"975cd64d00e6fa67cab2ec980794c7de",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -252,7 +253,7 @@
         }
     ],
     "wof:id":1091907919,
-    "wof:lastmodified":1690868510,
+    "wof:lastmodified":1695886592,
     "wof:name":"Sancti Spiritus",
     "wof:parent_id":85670413,
     "wof:placetype":"county",

--- a/data/109/190/796/9/1091907969.geojson
+++ b/data/109/190/796/9/1091907969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.152187,
-    "geom:area_square_m":1745126528.85675,
+    "geom:area_square_m":1745127180.636238,
     "geom:bbox":"-84.95208,21.754555,-83.960442,22.199555",
     "geom:latitude":21.972975,
     "geom:longitude":-84.358582,
@@ -108,9 +108,10 @@
         "hasc:id":"CU.PD.SA",
         "wd:id":"Q567769"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892469,
-    "wof:geomhash":"ccc669577a7e91f6169fe5926004ba4d",
+    "wof:geomhash":"e51a08bcee5b9c1826913c3dbee396b1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1091907969,
-    "wof:lastmodified":1690868510,
+    "wof:lastmodified":1695886592,
     "wof:name":"Sandino",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/800/9/1091908009.geojson
+++ b/data/109/190/800/9/1091908009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046164,
-    "geom:area_square_m":527737401.883677,
+    "geom:area_square_m":527737401.88359,
     "geom:bbox":"-80.0823136138,22.2679434353,-79.7614797533,22.5398842828",
     "geom:latitude":22.404587,
     "geom:longitude":-79.921604,
@@ -170,9 +170,10 @@
     "wof:concordances":{
         "hasc:id":"CU.VC.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892470,
-    "wof:geomhash":"54f8acb317d913fc3600825df508e96e",
+    "wof:geomhash":"9c7bc3216f33c4bf0248bfe22b573015",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1091908009,
-    "wof:lastmodified":1564327965,
+    "wof:lastmodified":1695886598,
     "wof:name":"Santa Clara",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/803/9/1091908039.geojson
+++ b/data/109/190/803/9/1091908039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032878,
-    "geom:area_square_m":373908962.027274,
+    "geom:area_square_m":373908760.019129,
     "geom:bbox":"-82.101069,23.015143,-81.670457,23.187944",
     "geom:latitude":23.111764,
     "geom:longitude":-81.851154,
@@ -132,9 +132,10 @@
         "hasc:id":"CU.MQ.SC",
         "wd:id":"Q270302"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892472,
-    "wof:geomhash":"af3c04fc77eee2f07d85b2918ded5396",
+    "wof:geomhash":"62ca98477a325305bbe3b1b18b0c7799",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1091908039,
-    "wof:lastmodified":1690868512,
+    "wof:lastmodified":1695886593,
     "wof:name":"Santa Cruz Del Norte",
     "wof:parent_id":85670461,
     "wof:placetype":"county",

--- a/data/109/190/808/5/1091908085.geojson
+++ b/data/109/190/808/5/1091908085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108885,
-    "geom:area_square_m":1258252629.41764,
+    "geom:area_square_m":1258253031.954044,
     "geom:bbox":"-78.954582,20.519583,-77.773584,21.05095",
     "geom:latitude":20.845827,
     "geom:longitude":-78.056711,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892473,
-    "wof:geomhash":"37d11a274a552d39e708e863c3aacdcc",
+    "wof:geomhash":"7019d5e7bc6ac71e6ee34d57bbeffd3d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091908085,
-    "wof:lastmodified":1627507748,
+    "wof:lastmodified":1695886720,
     "wof:name":"Santa Cruz Del Sur",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/813/7/1091908137.geojson
+++ b/data/109/190/813/7/1091908137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088344,
-    "geom:area_square_m":1026434667.911956,
+    "geom:area_square_m":1026434185.197632,
     "geom:bbox":"-76.07411,19.882973,-75.380369,20.129551",
     "geom:latitude":20.011405,
     "geom:longitude":-75.709969,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CU.SC.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892475,
-    "wof:geomhash":"d0b35225307d5091a54bccde0a7c1aba",
+    "wof:geomhash":"7f1e313d63456401f54c8029094a0340",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091908137,
-    "wof:lastmodified":1627507748,
+    "wof:lastmodified":1695886720,
     "wof:name":"Santiago De Cuba",
     "wof:parent_id":85670441,
     "wof:placetype":"county",

--- a/data/109/190/816/9/1091908169.geojson
+++ b/data/109/190/816/9/1091908169.geojson
@@ -362,9 +362,10 @@
     "wof:concordances":{
         "hasc:id":"CU.VC.SD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892476,
-    "wof:geomhash":"28848492dc4f42a3aaff8e31c94a18f3",
+    "wof:geomhash":"eaf6d442325fa1b0c626362e2842c08e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -374,7 +375,7 @@
         }
     ],
     "wof:id":1091908169,
-    "wof:lastmodified":1564327937,
+    "wof:lastmodified":1695886595,
     "wof:name":"Santo Domingo",
     "wof:parent_id":85670457,
     "wof:placetype":"county",

--- a/data/109/190/821/3/1091908213.geojson
+++ b/data/109/190/821/3/1091908213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046914,
-    "geom:area_square_m":543634261.020682,
+    "geom:area_square_m":543634261.020661,
     "geom:bbox":"-75.6749371233,20.3032841876,-75.3697074526,20.5458037167",
     "geom:latitude":20.423329,
     "geom:longitude":-75.520192,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"CU.SC.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892478,
-    "wof:geomhash":"87d0fb436df381f97a3f3a341c8ddafa",
+    "wof:geomhash":"7784d77eac44c5e6db705efc7516af80",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091908213,
-    "wof:lastmodified":1564327940,
+    "wof:lastmodified":1695886596,
     "wof:name":"Segundo Frente",
     "wof:parent_id":85670441,
     "wof:placetype":"county",

--- a/data/109/190/825/7/1091908257.geojson
+++ b/data/109/190/825/7/1091908257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063972,
-    "geom:area_square_m":737099197.59746,
+    "geom:area_square_m":737099293.876723,
     "geom:bbox":"-77.726588,21.070223,-77.421335,21.441257",
     "geom:latitude":21.279578,
     "geom:longitude":-77.571742,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892479,
-    "wof:geomhash":"2e491db3deb3621eda942b42885ef82e",
+    "wof:geomhash":"aa7bbb1c8abe87bcb8efbe211d15091c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091908257,
-    "wof:lastmodified":1627507748,
+    "wof:lastmodified":1695886720,
     "wof:name":"Sibanicu",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/830/1/1091908301.geojson
+++ b/data/109/190/830/1/1091908301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049227,
-    "geom:area_square_m":565694341.8348,
+    "geom:area_square_m":565693665.404083,
     "geom:bbox":"-77.936199,21.534878,-77.605222,21.787056",
     "geom:latitude":21.667966,
     "geom:longitude":-77.764235,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892481,
-    "wof:geomhash":"afcff1602ec7e7d3d244874380ad6844",
+    "wof:geomhash":"e1ae5f869f114898686b05f3ca4b9463",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091908301,
-    "wof:lastmodified":1627507748,
+    "wof:lastmodified":1695886720,
     "wof:name":"Sierra De Cubitas",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/834/7/1091908347.geojson
+++ b/data/109/190/834/7/1091908347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063008,
-    "geom:area_square_m":731215484.209816,
+    "geom:area_square_m":731215224.307524,
     "geom:bbox":"-75.78727,20.050615,-75.415821,20.341835",
     "geom:latitude":20.193698,
     "geom:longitude":-75.590524,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CU.SC.LM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892483,
-    "wof:geomhash":"cd369d262c9635b213448506e4a74008",
+    "wof:geomhash":"fb3b1cb53b607a67a6babb914a43faeb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091908347,
-    "wof:lastmodified":1627507748,
+    "wof:lastmodified":1695886720,
     "wof:name":"Songo La Maya",
     "wof:parent_id":85670441,
     "wof:placetype":"county",

--- a/data/109/190/839/7/1091908397.geojson
+++ b/data/109/190/839/7/1091908397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045403,
-    "geom:area_square_m":520341103.069678,
+    "geom:area_square_m":520340822.873489,
     "geom:bbox":"-79.438881,21.92827,-79.144414,22.185612",
     "geom:latitude":22.054622,
     "geom:longitude":-79.282818,
@@ -111,9 +111,10 @@
         "hasc:id":"CU.SS.TA",
         "wd:id":"Q862734"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892484,
-    "wof:geomhash":"8bad39755fa69b06f159df2169d6ee56",
+    "wof:geomhash":"1576d385e5f1acecd47331c6efba5791",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1091908397,
-    "wof:lastmodified":1690868520,
+    "wof:lastmodified":1695886594,
     "wof:name":"Taguasco",
     "wof:parent_id":85670413,
     "wof:placetype":"county",

--- a/data/109/190/843/9/1091908439.geojson
+++ b/data/109/190/843/9/1091908439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031051,
-    "geom:area_square_m":360466384.222405,
+    "geom:area_square_m":360466384.22239,
     "geom:bbox":"-76.4288928747,20.0496541948,-76.1563398401,20.2432708714",
     "geom:latitude":20.144588,
     "geom:longitude":-76.303155,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"CU.SC.TF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892486,
-    "wof:geomhash":"8749e0174b6c756adb6a31ce829b6557",
+    "wof:geomhash":"6783eae24df501454e5dbe7533be7a59",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091908439,
-    "wof:lastmodified":1564327941,
+    "wof:lastmodified":1695886596,
     "wof:name":"Tercer Frente",
     "wof:parent_id":85670441,
     "wof:placetype":"county",

--- a/data/109/190/847/3/1091908473.geojson
+++ b/data/109/190/847/3/1091908473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102291,
-    "geom:area_square_m":1173983241.676385,
+    "geom:area_square_m":1173983646.197925,
     "geom:bbox":"-80.110627,21.667084,-79.611621,22.023513",
     "geom:latitude":21.850289,
     "geom:longitude":-79.858899,
@@ -228,9 +228,10 @@
         "hasc:id":"CU.SS.TR",
         "wd:id":"Q319272"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892487,
-    "wof:geomhash":"e3793051f2749f9676b1730a7638b9e3",
+    "wof:geomhash":"fc8bd1072ad561a7bfc59f1065c3ad4c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -240,7 +241,7 @@
         }
     ],
     "wof:id":1091908473,
-    "wof:lastmodified":1690868519,
+    "wof:lastmodified":1695886160,
     "wof:name":"Trinidad",
     "wof:parent_id":85670413,
     "wof:placetype":"county",

--- a/data/109/190/851/7/1091908517.geojson
+++ b/data/109/190/851/7/1091908517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075561,
-    "geom:area_square_m":861795069.417152,
+    "geom:area_square_m":861795374.806568,
     "geom:bbox":"-81.695264,22.507544,-81.333375,22.94572",
     "geom:latitude":22.7248,
     "geom:longitude":-81.540757,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892488,
-    "wof:geomhash":"9cff8de4e873635d41bf8b58012275b3",
+    "wof:geomhash":"294b88c650ebbf203b0cd74b9364a353",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091908517,
-    "wof:lastmodified":1627507748,
+    "wof:lastmodified":1695886720,
     "wof:name":"Union De Reyes",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/856/1/1091908561.geojson
+++ b/data/109/190/856/1/1091908561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073438,
-    "geom:area_square_m":850080469.613026,
+    "geom:area_square_m":850080469.6131,
     "geom:bbox":"-76.4543470189,20.4003686243,-76.0021356043,20.7165205452",
     "geom:latitude":20.587654,
     "geom:longitude":-76.204867,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"CU.HO.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892490,
-    "wof:geomhash":"f8265f16a7312beb0924fe90b5ca6b13",
+    "wof:geomhash":"deac60d5eb849118c3dcdf651d7a84c2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091908561,
-    "wof:lastmodified":1564327944,
+    "wof:lastmodified":1695886596,
     "wof:name":"Urbano Noris",
     "wof:parent_id":85670435,
     "wof:placetype":"county",

--- a/data/109/190/859/1/1091908591.geojson
+++ b/data/109/190/859/1/1091908591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001813,
-    "geom:area_square_m":20612620.610892,
+    "geom:area_square_m":20612620.610891,
     "geom:bbox":"-81.2943694445,23.1326271466,-81.120475769,23.206222534",
     "geom:latitude":23.175614,
     "geom:longitude":-81.196779,
@@ -151,9 +151,10 @@
     "wof:concordances":{
         "hasc:id":"CU.MA.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892491,
-    "wof:geomhash":"44afa6617128e85ddb6cef563d57d334",
+    "wof:geomhash":"70c531dd2ba6caa648c15d063a25caed",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":1091908591,
-    "wof:lastmodified":1564327942,
+    "wof:lastmodified":1695886596,
     "wof:name":"Varadero",
     "wof:parent_id":85670455,
     "wof:placetype":"county",

--- a/data/109/190/860/3/1091908603.geojson
+++ b/data/109/190/860/3/1091908603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139056,
-    "geom:area_square_m":1598065629.851841,
+    "geom:area_square_m":1598065943.539983,
     "geom:bbox":"-79.451248,20.836195,-78.329979,21.914312",
     "geom:latitude":21.657605,
     "geom:longitude":-78.712196,
@@ -118,9 +118,10 @@
         "hasc:id":"CU.CA.VE",
         "wd:id":"Q593830"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892493,
-    "wof:geomhash":"11d1e4109a6e4baf54c34771d6e4b6e4",
+    "wof:geomhash":"4b909d386c1c5c90612f42cdd997684f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1091908603,
-    "wof:lastmodified":1690868514,
+    "wof:lastmodified":1695886593,
     "wof:name":"Venezuela",
     "wof:parent_id":85670419,
     "wof:placetype":"county",

--- a/data/109/190/866/3/1091908663.geojson
+++ b/data/109/190/866/3/1091908663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.174733,
-    "geom:area_square_m":2015334479.63033,
+    "geom:area_square_m":2015334479.630632,
     "geom:bbox":"-78.532142639,20.827110291,-77.9967355691,21.3694429414",
     "geom:latitude":21.129944,
     "geom:longitude":-78.262832,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"CU.CM.VE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892495,
-    "wof:geomhash":"4652ee62a27f9c047e251c37994f4b76",
+    "wof:geomhash":"d33c45b3cd2baa5891585746a70c6e10",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091908663,
-    "wof:lastmodified":1564327942,
+    "wof:lastmodified":1695886596,
     "wof:name":"Vertientes",
     "wof:parent_id":85670423,
     "wof:placetype":"county",

--- a/data/109/190/869/1/1091908691.geojson
+++ b/data/109/190/869/1/1091908691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061274,
-    "geom:area_square_m":699332594.660823,
+    "geom:area_square_m":699332400.146453,
     "geom:bbox":"-83.884729,22.46738,-83.58138,22.817888",
     "geom:latitude":22.630622,
     "geom:longitude":-83.739578,
@@ -123,9 +123,10 @@
         "hasc:id":"CU.PD.VI",
         "wd:id":"Q1180693"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892496,
-    "wof:geomhash":"acff0ff55318cdcdc8d24773cd890167",
+    "wof:geomhash":"4635b731cedb2c81dca7458647492deb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1091908691,
-    "wof:lastmodified":1690868514,
+    "wof:lastmodified":1695886593,
     "wof:name":"Vinales",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/109/190/873/5/1091908735.geojson
+++ b/data/109/190/873/5/1091908735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090469,
-    "geom:area_square_m":1035106180.842832,
+    "geom:area_square_m":1035106747.013495,
     "geom:bbox":"-79.416936,22.091914,-78.92313,22.461222",
     "geom:latitude":22.286066,
     "geom:longitude":-79.168103,
@@ -120,9 +120,10 @@
         "hasc:id":"CU.SS.YA",
         "wd:id":"Q862092"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892498,
-    "wof:geomhash":"3308be473cb1f4d51075bdf8c8503208",
+    "wof:geomhash":"cf635008dba55df787823d60646315ee",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1091908735,
-    "wof:lastmodified":1690868512,
+    "wof:lastmodified":1695886593,
     "wof:name":"Yaguajay",
     "wof:parent_id":85670413,
     "wof:placetype":"county",

--- a/data/109/190/874/1/1091908741.geojson
+++ b/data/109/190/874/1/1091908741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049245,
-    "geom:area_square_m":570969938.662675,
+    "geom:area_square_m":570970042.031162,
     "geom:bbox":"-77.105378,20.160612,-76.784047,20.500834",
     "geom:latitude":20.33477,
     "geom:longitude":-76.954454,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GR.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892499,
-    "wof:geomhash":"a7e51bf101fee73082c372179484b85a",
+    "wof:geomhash":"d640f647f104244c2480de461d485057",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1091908741,
-    "wof:lastmodified":1627507748,
+    "wof:lastmodified":1695886720,
     "wof:name":"Yara",
     "wof:parent_id":85670431,
     "wof:placetype":"county",

--- a/data/109/190/874/3/1091908743.geojson
+++ b/data/109/190/874/3/1091908743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05855,
-    "geom:area_square_m":678817322.3038,
+    "geom:area_square_m":678817322.303718,
     "geom:bbox":"-75.12043742,20.1985473022,-74.6931939558,20.4722028913",
     "geom:latitude":20.344918,
     "geom:longitude":-74.924894,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"CU.GU.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892501,
-    "wof:geomhash":"e585f0417c7723d1f10540f8cfa7b8aa",
+    "wof:geomhash":"b20d47189d6f8ea5e75ea033d9d89112",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091908743,
-    "wof:lastmodified":1564327939,
+    "wof:lastmodified":1695886595,
     "wof:name":"Yateras",
     "wof:parent_id":85670425,
     "wof:placetype":"county",

--- a/data/136/066/725/1/1360667251.geojson
+++ b/data/136/066/725/1/1360667251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066164,
-    "geom:area_square_m":767445072.992762,
+    "geom:area_square_m":767445072.992841,
     "geom:bbox":"-75.988736,20.089908,-75.639836,20.456493",
     "geom:latitude":20.273903,
     "geom:longitude":-75.810546,
@@ -139,9 +139,10 @@
         "hasc:id":"CU.SC.SL",
         "wd:id":"Q555956"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892463,
-    "wof:geomhash":"3e392d8b3fd269cffdbd3ce4f408fe13",
+    "wof:geomhash":"29118b9a1aab2a7d63384fce3ffee895",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1360667251,
-    "wof:lastmodified":1690868507,
+    "wof:lastmodified":1695886158,
     "wof:name":"San Luis",
     "wof:parent_id":85670441,
     "wof:placetype":"county",

--- a/data/136/066/725/3/1360667253.geojson
+++ b/data/136/066/725/3/1360667253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028967,
-    "geom:area_square_m":331531060.540384,
+    "geom:area_square_m":331531085.164173,
     "geom:bbox":"-83.830288,22.162889,-83.584301,22.353837",
     "geom:latitude":22.24376,
     "geom:longitude":-83.716051,
@@ -130,9 +130,10 @@
         "hasc:id":"CU.PR.SL",
         "wd:id":"Q1817531"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1473892463,
-    "wof:geomhash":"85f498cb68ed64fb0dfb6ac809e32cb2",
+    "wof:geomhash":"cc353842ac441d831f921b2a91ee12d3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1360667253,
-    "wof:lastmodified":1690868508,
+    "wof:lastmodified":1695886158,
     "wof:name":"San Luis",
     "wof:parent_id":85670409,
     "wof:placetype":"county",

--- a/data/856/326/75/85632675.geojson
+++ b/data/856/326/75/85632675.geojson
@@ -1180,6 +1180,7 @@
         "hasc:id":"CU",
         "icao:code":"CU",
         "ioc:id":"CUB",
+        "iso:code":"CU",
         "itu:id":"CUB",
         "loc:id":"n79079435",
         "m49:code":"192",
@@ -1194,6 +1195,7 @@
         "wk:page":"Cuba",
         "wmo:id":"CU"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:country_alpha3":"CUB",
     "wof:geom_alt":[
@@ -1215,7 +1217,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1694639563,
+    "wof:lastmodified":1695881222,
     "wof:name":"Cuba",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/704/03/85670403.geojson
+++ b/data/856/704/03/85670403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.373522,
-    "geom:area_square_m":4275130239.384547,
+    "geom:area_square_m":4275130635.131387,
     "geom:bbox":"-80.931183,21.818494,-80.02873,22.586273",
     "geom:latitude":22.237389,
     "geom:longitude":-80.444707,
@@ -328,17 +328,19 @@
         "gn:id":3564120,
         "gp:id":2345112,
         "hasc:id":"CU.CF",
+        "iso:code":"CU-06",
         "iso:id":"CU-06",
         "qs:id":235574,
         "unlc:id":"CU-06",
         "wd:id":"Q115444",
         "wk:page":"Cienfuegos Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b95b6b58dd867bd86516fd986eef626",
+    "wof:geomhash":"9788dbf47b87446e57e29797eb980b78",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -353,7 +355,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868497,
+    "wof:lastmodified":1695884957,
     "wof:name":"Cienfuegos",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/05/85670405.geojson
+++ b/data/856/704/05/85670405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.207704,
-    "geom:area_square_m":2386695957.372408,
+    "geom:area_square_m":2386695957.371999,
     "geom:bbox":"-83.207947,21.439556,-81.359581,21.947056",
     "geom:latitude":21.674996,
     "geom:longitude":-82.788054,
@@ -304,11 +304,13 @@
         "gn:id":3556608,
         "gp:id":2345109,
         "hasc:id":"CU.IJ",
+        "iso:code":"CU-99",
         "iso:id":"CU-99",
         "qs:id":423683,
         "unlc:id":"CU-99",
         "wd:id":"Q12588"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1091906563
     ],
@@ -316,7 +318,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cec96f12402e17d458e7df3112d5d37b",
+    "wof:geomhash":"7d7002081fe50dbb38749e065f2b582f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868498,
+    "wof:lastmodified":1695884477,
     "wof:name":"Isla de la Juventud",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/09/85670409.geojson
+++ b/data/856/704/09/85670409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.959019,
-    "geom:area_square_m":10960823343.491816,
+    "geom:area_square_m":10960823572.259926,
     "geom:bbox":"-84.95208,21.754555,-82.833583,23.01375",
     "geom:latitude":22.434718,
     "geom:longitude":-83.721856,
@@ -341,17 +341,19 @@
         "gn:id":3544088,
         "gp:id":2345106,
         "hasc:id":"CU.PD",
+        "iso:code":"CU-01",
         "iso:id":"CU-01",
         "qs:id":219533,
         "unlc:id":"CU-01",
         "wd:id":"Q115497",
         "wk:page":"Pinar del R\u00edo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6f12e6f8c7bd614bfdf25b9089a17564",
+    "wof:geomhash":"9b0376bcc86e9335bb4f82fe4f0fa781",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -366,7 +368,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868499,
+    "wof:lastmodified":1695884503,
     "wof:name":"Pinar Del Rio",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/13/85670413.geojson
+++ b/data/856/704/13/85670413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.589656,
-    "geom:area_square_m":6762616336.108855,
+    "geom:area_square_m":6762617349.477057,
     "geom:bbox":"-80.110627,21.542055,-78.92313,22.461222",
     "geom:latitude":21.950317,
     "geom:longitude":-79.422951,
@@ -344,17 +344,19 @@
         "gn:id":3540665,
         "gp:id":2345118,
         "hasc:id":"CU.SS",
+        "iso:code":"CU-07",
         "iso:id":"CU-07",
         "qs:id":219535,
         "unlc:id":"CU-07",
         "wd:id":"Q115441",
         "wk:page":"Sancti Sp\u00edritus Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9ac47eaf4d70fab224d7528ceb3fdcc2",
+    "wof:geomhash":"01c7a446dd45b2c316197fcd8ae9ffde",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -369,7 +371,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868501,
+    "wof:lastmodified":1695884503,
     "wof:name":"Sancti Spiritus",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/19/85670419.geojson
+++ b/data/856/704/19/85670419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.596099,
-    "geom:area_square_m":6835265556.103239,
+    "geom:area_square_m":6835264995.993061,
     "geom:bbox":"-79.451248,20.836195,-78.069712,22.61536",
     "geom:latitude":21.975663,
     "geom:longitude":-78.649067,
@@ -311,17 +311,19 @@
         "gn:id":3564175,
         "gp:id":2345111,
         "hasc:id":"CU.CA",
+        "iso:code":"CU-08",
         "iso:id":"CU-08",
         "qs:id":235575,
         "unlc:id":"CU-08",
         "wd:id":"Q220692",
         "wk:page":"Ciego de \u00c1vila Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a176bb8f1de81fcdb40e7e04217b7e23",
+    "wof:geomhash":"77a35ffc93aa869f7513d1e5ac28eee2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868498,
+    "wof:lastmodified":1695884503,
     "wof:name":"Ciego de \u00c1vila",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/23/85670423.geojson
+++ b/data/856/704/23/85670423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.376656,
-    "geom:area_square_m":15848118578.863031,
+    "geom:area_square_m":15848118650.962585,
     "geom:bbox":"-78.954582,20.519583,-76.951279,22.482916",
     "geom:latitude":21.405564,
     "geom:longitude":-77.873225,
@@ -340,17 +340,19 @@
         "gn:id":3566062,
         "gp:id":2345110,
         "hasc:id":"CU.CM",
+        "iso:code":"CU-09",
         "iso:id":"CU-09",
         "qs:id":423696,
         "unlc:id":"CU-09",
         "wd:id":"Q215147",
         "wk:page":"Camag\u00fcey Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7d0ee8246bc57cec2161475b1fd50cde",
+    "wof:geomhash":"ae13f3da96903b638a320f158c547760",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -365,7 +367,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868500,
+    "wof:lastmodified":1695884503,
     "wof:name":"Camag\u00fcey",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/25/85670425.geojson
+++ b/data/856/704/25/85670425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.537779,
-    "geom:area_square_m":6240574964.203363,
+    "geom:area_square_m":6240576014.187192,
     "geom:bbox":"-75.494284,19.878805,-74.133781,20.568798",
     "geom:latitude":20.203635,
     "geom:longitude":-74.90971,
@@ -298,17 +298,19 @@
         "gn:id":3557685,
         "gp:id":2345114,
         "hasc:id":"CU.GU",
+        "iso:code":"CU-14",
         "iso:id":"CU-14",
         "qs:id":423632,
         "unlc:id":"CU-14",
         "wd:id":"Q115319",
         "wk:page":"Guant\u00e1namo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1d297c971d501a8ad590940bb08894db",
+    "wof:geomhash":"2fc91d523094ea71d6f5bc38d26c20e8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868501,
+    "wof:lastmodified":1695884503,
     "wof:name":"Guantanamo",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/31/85670431.geojson
+++ b/data/856/704/31/85670431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.727086,
-    "geom:area_square_m":8432551671.437721,
+    "geom:area_square_m":8432551641.164582,
     "geom:bbox":"-77.74128,19.82625,-76.196177,20.774852",
     "geom:latitude":20.291217,
     "geom:longitude":-76.920268,
@@ -337,17 +337,19 @@
         "gn:id":3558052,
         "gp:id":2345113,
         "hasc:id":"CU.GR",
+        "iso:code":"CU-12",
         "iso:id":"CU-12",
         "qs:id":219521,
         "unlc:id":"CU-12",
         "wd:id":"Q115046",
         "wk:page":"Granma Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2a715f38ca97e084bb3fd5c210fcd486",
+    "wof:geomhash":"3542436286336b11f38d065cc1ad67fb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -362,7 +364,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868499,
+    "wof:lastmodified":1695884957,
     "wof:name":"Granma",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/35/85670435.geojson
+++ b/data/856/704/35/85670435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.809218,
-    "geom:area_square_m":9356927582.675303,
+    "geom:area_square_m":9356925488.910027,
     "geom:bbox":"-76.72763,20.378524,-74.718733,21.245784",
     "geom:latitude":20.751823,
     "geom:longitude":-75.877604,
@@ -343,17 +343,19 @@
         "gn:id":3556965,
         "gp:id":2345116,
         "hasc:id":"CU.HO",
+        "iso:code":"CU-11",
         "iso:id":"CU-11",
         "qs:id":235573,
         "unlc:id":"CU-11",
         "wd:id":"Q115302",
         "wk:page":"Holgu\u00edn Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f446b3ff375ce78090a416602820ea69",
+    "wof:geomhash":"891c7d91915d6b1e306971a48065ba40",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -368,7 +370,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868497,
+    "wof:lastmodified":1695884503,
     "wof:name":"Holguin",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/39/85670439.geojson
+++ b/data/856/704/39/85670439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.573078,
-    "geom:area_square_m":6615135879.437184,
+    "geom:area_square_m":6615135595.004243,
     "geom:bbox":"-77.831005,20.642084,-76.30662,21.457651",
     "geom:latitude":21.008828,
     "geom:longitude":-77.032347,
@@ -334,17 +334,19 @@
         "gn:id":3550595,
         "gp:id":2345117,
         "hasc:id":"CU.LT",
+        "iso:code":"CU-10",
         "iso:id":"CU-10",
         "qs:id":219534,
         "unlc:id":"CU-10",
         "wd:id":"Q115334",
         "wk:page":"Las Tunas Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9d91cf9d6ea68457d9ae332dd20819ab",
+    "wof:geomhash":"060fbe0d8e2b200e1e71dc1d5f6d9fe8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -359,7 +361,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868499,
+    "wof:lastmodified":1695884957,
     "wof:name":"Las Tunas",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/41/85670441.geojson
+++ b/data/856/704/41/85670441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.534264,
-    "geom:area_square_m":6200459449.043439,
+    "geom:area_square_m":6200459398.810125,
     "geom:bbox":"-77.056775,19.882973,-75.369707,20.571683",
     "geom:latitude":20.18638,
     "geom:longitude":-75.966889,
@@ -315,17 +315,19 @@
         "gn:id":3536725,
         "gp:id":2345119,
         "hasc:id":"CU.SC",
+        "iso:code":"CU-13",
         "iso:id":"CU-13",
         "qs:id":423701,
         "unlc:id":"CU-13",
         "wd:id":"Q234200",
         "wk:page":"Santiago de Cuba Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5afe3e55ef5051bd815dc4c38d62a7da",
+    "wof:geomhash":"3a6da214c0197aeb3438d4896971b793",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -340,7 +342,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868500,
+    "wof:lastmodified":1695884957,
     "wof:name":"Santiago de Cuba",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/45/85670445.geojson
+++ b/data/856/704/45/85670445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065845,
-    "geom:area_square_m":749076961.819265,
+    "geom:area_square_m":749076238.935793,
     "geom:bbox":"-82.538978,22.932974,-82.074825,23.18125",
     "geom:latitude":23.069728,
     "geom:longitude":-82.306896,
@@ -234,12 +234,14 @@
         "gn:id":3564073,
         "gp:id":2345107,
         "hasc:id":"CU.CH",
+        "iso:code":"CU-03",
         "iso:id":"CU-03",
         "qs:id":428296,
         "unlc:id":"CU-03",
         "wd:id":"Q274126",
         "wk:page":"La Habana Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421186583
     ],
@@ -247,7 +249,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0877133207736721797a1fa1503e9174",
+    "wof:geomhash":"fca8498d225992be891f3b1d0fa76513",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -262,7 +264,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868498,
+    "wof:lastmodified":1695884737,
     "wof:name":"Ciudad De La Habana",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/49/85670449.geojson
+++ b/data/856/704/49/85670449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.174734,
-    "geom:area_square_m":1991062286.887152,
+    "geom:area_square_m":1991062259.326232,
     "geom:bbox":"-82.982568,22.54789,-82.426146,23.07656",
     "geom:latitude":22.850295,
     "geom:longitude":-82.694715,
@@ -274,15 +274,17 @@
         "fips:code":"CU17",
         "gp:id":2345115,
         "hasc:id":"CU.AR",
+        "iso:code":"CU-15",
         "iso:id":"CU-15",
         "unlc:id":"CU-15",
         "wd:id":"Q115006"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e3ce5f295fe76ce2f05a90b116d1b4c1",
+    "wof:geomhash":"3cd691c281d8cea64c2635f7ec01edbf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -297,7 +299,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868501,
+    "wof:lastmodified":1695884957,
     "wof:name":"Artemisa",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/55/85670455.geojson
+++ b/data/856/704/55/85670455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.040756,
-    "geom:area_square_m":11880244946.028805,
+    "geom:area_square_m":11880246076.303883,
     "geom:bbox":"-82.159637,22.018749,-80.469612,23.277082",
     "geom:latitude":22.60621,
     "geom:longitude":-81.216557,
@@ -337,17 +337,19 @@
         "gn:id":3547394,
         "gp:id":2345108,
         "hasc:id":"CU.MA",
+        "iso:code":"CU-04",
         "iso:id":"CU-04",
         "qs:id":423676,
         "unlc:id":"CU-04",
         "wd:id":"Q115438",
         "wk:page":"Matanzas Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c95c03ec0a7f35d59d78eba3af1bac03",
+    "wof:geomhash":"c073bd9a3dc935fb3366ecf7361191d8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -362,7 +364,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868500,
+    "wof:lastmodified":1695884378,
     "wof:name":"Matanzas",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/57/85670457.geojson
+++ b/data/856/704/57/85670457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.737526,
-    "geom:area_square_m":8422046946.157617,
+    "geom:area_square_m":8422045323.599999,
     "geom:bbox":"-80.754431,21.953379,-78.956276,23.15625",
     "geom:latitude":22.554676,
     "geom:longitude":-79.991298,
@@ -310,17 +310,19 @@
         "gn:id":3534168,
         "gp:id":2345120,
         "hasc:id":"CU.VC",
+        "iso:code":"CU-05",
         "iso:id":"CU-05",
         "qs:id":423714,
         "unlc:id":"CU-05",
         "wd:id":"Q115434",
         "wk:page":"Villa Clara Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2610b6c8c02a59023122acc23476e0d7",
+    "wof:geomhash":"70890e3f673d500d5226ee7e92db21f0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -335,7 +337,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868497,
+    "wof:lastmodified":1695884377,
     "wof:name":"Villa Clara",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/856/704/61/85670461.geojson
+++ b/data/856/704/61/85670461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.327145,
-    "geom:area_square_m":3727072587.543743,
+    "geom:area_square_m":3727072905.305727,
     "geom:bbox":"-82.470594,22.572056,-81.581603,23.187944",
     "geom:latitude":22.874819,
     "geom:longitude":-82.005385,
@@ -127,15 +127,17 @@
         "fips:code":"CU18",
         "gp:id":2345115,
         "hasc:id":"CU.MQ",
+        "iso:code":"CU-16",
         "iso:id":"CU-16",
         "unlc:id":"CU-16",
         "wd:id":"Q1914389"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CU",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d63183381a1a16a739aec9e5b9bd29f0",
+    "wof:geomhash":"f2a3451fe43cd2375561fffebf79177d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -150,7 +152,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690868496,
+    "wof:lastmodified":1695884957,
     "wof:name":"Mayabeque",
     "wof:parent_id":85632675,
     "wof:placetype":"region",

--- a/data/890/445/471/890445471.geojson
+++ b/data/890/445/471/890445471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020467,
-    "geom:area_square_m":233353036.702286,
+    "geom:area_square_m":233353029.364944,
     "geom:bbox":"-82.241324,22.671163,-82.058846,22.859877",
     "geom:latitude":22.769621,
     "geom:longitude":-82.145105,
@@ -63,12 +63,13 @@
         "hasc:id":"CU.LH.MS",
         "qs:id":583418
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CU",
     "wof:created":1469052511,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5509bbb77c12758a3363320e043de630",
+    "wof:geomhash":"02329411813e2264e17f554686df762e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":890445471,
-    "wof:lastmodified":1627507747,
+    "wof:lastmodified":1695886719,
     "wof:name":"Melena Del Sur",
     "wof:parent_id":85670461,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.